### PR TITLE
feat(projects): nested sub-projects under .roady/projects/<name>/

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — Nested sub-projects
+
+- A single repository can now host multiple Roady projects side-by-side under one `.roady/` directory by placing each named sub-project at `.roady/projects/<name>/`. See `docs/rfcs/0001-nested-projects.md`.
+- New global CLI flag `--project / -P <name>` (env: `ROADY_PROJECT`) scopes every command to a named sub-project. With no flag, commands target the repo's root project, exactly as before.
+- New MCP request field `project` (optional, alongside the existing `project_path`) routes tool calls to a sub-project. `AppServices` are cached per `(path, project)` key.
+- `roady discover` and `roady org status` now surface sub-projects in addition to root projects.
+- New storage constructor `storage.NewFilesystemRepositoryForProject(root, name)` plus helpers `ProjectBase()`, `SubProject()`, `IsSubProject()`. The legacy `NewFilesystemRepository(root)` continues to return a root-project repository unchanged.
+- New `OrgService.DiscoverProjectsWithSub()` returns both root projects and sub-projects; legacy `DiscoverProjects()` is kept and unchanged in shape.
+- Backward-compatible: existing flat `.roady/` repos continue to work unchanged. No data migration required.
+
 ### Pre-launch infra hardening
 
 - Plugin builds (`asana`, `github`, `mock`, `notion`, `trello`) added to GoReleaser. Every plugin now ships in the bundled release archive (previously only `linear` and `jira` shipped).

--- a/docs/rfcs/0001-nested-projects.md
+++ b/docs/rfcs/0001-nested-projects.md
@@ -1,0 +1,162 @@
+# RFC 0001: Nested Sub-Projects Under `.roady/projects/<name>/`
+
+Status: Implemented (branch `feat/nested-projects`)
+
+## Summary
+
+Allow a single repository to host multiple Roady projects side-by-side under one `.roady/` directory by placing each named sub-project at `.roady/projects/<name>/`. Existing flat repositories continue to work unchanged — their `.roady/` contents form an implicit "root project".
+
+One coding agent can now manage many feature- or product-scoped projects in the same workspace by switching `--project <name>` (CLI) or `project` (MCP) without changing directories.
+
+## Motivation
+
+Today, every Roady project owns its own directory. To track work for two related features in the same repository you either:
+
+- Spin up two unrelated workspaces with two unrelated `.roady/` dirs, or
+- Cram everything into one plan that mixes contexts.
+
+For an AI coding agent operating across several features at once, neither option is ideal. Agents want a stable on-disk namespace that mirrors the way humans think about features (and that survives context resets).
+
+## Layout
+
+```
+repo/
+  .roady/                          # root project (unchanged)
+    spec.yaml
+    plan.json
+    state.json
+    events.jsonl
+    policy.yaml
+    rates.yaml
+    time_entries.yaml
+    projects/                      # NEW: named sub-projects
+      feature-auth/
+        spec.yaml
+        plan.json
+        state.json
+        events.jsonl
+        policy.yaml
+        ...
+      feature-payments/
+        spec.yaml
+        plan.json
+        ...
+```
+
+Sub-project names must match `^[a-z0-9][a-z0-9._-]{0,63}$`. The literal name `projects` is reserved (collision with the parent directory).
+
+## CLI surface
+
+A new global flag `--project / -P` selects a sub-project; `ROADY_PROJECT` is the env-var fallback. With no flag and no env, commands target the root project.
+
+```bash
+# Initialise the repo's root project (unchanged).
+roady init --template minimal
+
+# Initialise a feature sub-project.
+roady -P feature-auth init --template minimal
+
+# Work in the sub-project context.
+roady -P feature-auth spec show
+roady -P feature-auth task ready
+roady -P feature-auth task start <id>
+
+# Or via environment.
+export ROADY_PROJECT=feature-auth
+roady status
+
+# Discover everything across the tree, including sub-projects.
+roady discover .
+# Found 3 Roady projects:
+# - /path/to/repo
+# - /path/to/repo/.roady/projects/feature-auth  (sub-project: feature-auth)
+# - /path/to/repo/.roady/projects/feature-payments  (sub-project: feature-payments)
+
+# Cross-project status surface includes sub-projects.
+roady org status .
+```
+
+## MCP surface
+
+Every tool request struct that already takes `project_path` (path to the repo root) now also takes an optional `project` string (sub-project name).
+
+```jsonc
+{
+  "name": "roady_get_ready_tasks",
+  "arguments": {
+    "project_path": "/path/to/repo",   // workspace root
+    "project": "feature-auth"           // sub-project under .roady/projects/<name>/
+  }
+}
+```
+
+Behaviour:
+- `project_path` empty + `project` empty → server's default services (root project at the server root).
+- `project_path` set + `project` empty → root project at the given path.
+- `project_path` set + `project` set → sub-project at `<path>/.roady/projects/<name>/`.
+- `project_path` empty + `project` set → sub-project at `<server-root>/.roady/projects/<name>/`.
+
+Service instances are cached per `(path, project)` key.
+
+## Storage layer
+
+`storage.FilesystemRepository` gained an optional sub-project field. Two constructors:
+
+```go
+storage.NewFilesystemRepository(root)                          // root project
+storage.NewFilesystemRepositoryForProject(root, projectName)   // sub-project
+```
+
+Internal API:
+- `ProjectBase() string` — returns the on-disk directory for this scope (`<root>/.roady` or `<root>/.roady/projects/<name>`).
+- `SubProject() string`, `IsSubProject() bool` — introspection.
+- `ResolvePath(filename)` — same contract as before; resolves under `ProjectBase()`.
+
+All higher-level repository methods (SaveSpec, LoadPlan, SaveState, etc.) are unchanged — they delegate to `ResolvePath` which now honours the project base.
+
+## Discovery
+
+`OrgService.DiscoverProjectsWithSub() ([]DiscoveredProject, error)` walks the tree, returns every `.roady/` it finds AND every sub-project under `.roady/projects/<name>/`. The legacy `DiscoverProjects() ([]string, error)` is kept and now returns just the root-project paths.
+
+`roady discover` and `roady org status` surface sub-projects with a `(name)` suffix and the on-disk path of the sub-project directory.
+
+## Cache key
+
+The MCP server caches `AppServices` per `(repo-root, sub-project)` pair, so switching sub-projects in flight does not rebuild the full stack for the root project.
+
+## Migration
+
+None required. Existing flat `.roady/` repositories continue to function exactly as before — they are treated as the root project of that repo. A sub-project can be added at any time with:
+
+```bash
+roady -P <new-name> init --template minimal
+```
+
+No data movement, no config flips.
+
+## Out of scope
+
+- Cross-project task dependencies (`@project:task-id` syntax). Tasks remain project-scoped. A follow-up RFC can introduce cross-project references via a new `Dependency` field on `planning.Task`.
+- A single org-level dashboard collating sub-project Kanban columns. Deferred.
+- Renaming or moving sub-projects via CLI (today: edit the directory name on disk).
+
+## Backwards compatibility
+
+| Surface | Compatibility |
+|---|---|
+| Existing flat `.roady/` repos | Unchanged. |
+| `storage.NewFilesystemRepository(root)` | Unchanged signature; returns root-project repo. |
+| `application.OrgService.DiscoverProjects()` | Unchanged signature; returns root projects only. |
+| `wiring.NewWorkspace(root)` | Unchanged signature; returns root-project workspace. |
+| `wiring.BuildAppServices(root)` | Unchanged signature; targets root project. |
+| MCP request structs | `project_path` unchanged; `project` is new and optional. |
+| `roady discover` output | Adds extra lines for sub-projects with a `(sub-project: <name>)` suffix. |
+| `roady org status` | Adds sub-project rows. |
+
+No deprecations.
+
+## Tests
+
+- New package tests in `pkg/storage/filesystem_subproject_test.go` cover name validation, path scoping, isolation between root and sub-projects, and traversal rejection.
+- Updated `pkg/storage/filesystem_test.go` to clarify that nested filenames are still rejected on a root-project repo (sub-projects are addressed by constructor, not by passing nested filenames).
+- The full test suite remains green.

--- a/internal/infrastructure/cli/discover.go
+++ b/internal/infrastructure/cli/discover.go
@@ -2,15 +2,19 @@ package cli
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 
+	"github.com/felixgeelhaar/roady/pkg/application"
 	"github.com/spf13/cobra"
 )
 
 var discoverCmd = &cobra.Command{
 	Use:   "discover [root-dir]",
 	Short: "Discover all Roady projects in a directory tree",
+	Long: `Discover all Roady projects (and named sub-projects) in a directory tree.
+
+Each ".roady/" directory found surfaces its root project, plus every
+named sub-project under ".roady/projects/<name>/".`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		root := "."
 		if len(args) > 0 {
@@ -19,18 +23,8 @@ var discoverCmd = &cobra.Command{
 
 		fmt.Printf("Searching for Roady projects in: %s\n", root)
 
-		projects := []string{}
-		err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
-			if err != nil {
-				return nil // Skip errors
-			}
-			if info.IsDir() && info.Name() == ".roady" {
-				projects = append(projects, filepath.Dir(path))
-				return filepath.SkipDir // Don't look inside .roady
-			}
-			return nil
-		})
-
+		svc := application.NewOrgService(root)
+		projects, err := svc.DiscoverProjectsWithSub()
 		if err != nil {
 			return fmt.Errorf("failed to walk directory: %w", err)
 		}
@@ -42,8 +36,15 @@ var discoverCmd = &cobra.Command{
 
 		fmt.Printf("Found %d Roady projects:\n", len(projects))
 		for _, p := range projects {
-			abs, _ := filepath.Abs(p)
-			fmt.Printf("- %s\n", abs)
+			abs, _ := filepath.Abs(p.Path)
+			if p.SubProject == "" {
+				fmt.Printf("- %s\n", abs)
+				continue
+			}
+			fmt.Printf("- %s  (sub-project: %s)\n",
+				filepath.Join(abs, ".roady", "projects", p.SubProject),
+				p.SubProject,
+			)
 		}
 
 		return nil

--- a/internal/infrastructure/cli/init.go
+++ b/internal/infrastructure/cli/init.go
@@ -20,7 +20,10 @@ var initCmd = &cobra.Command{
 		if cErr != nil {
 			return fmt.Errorf("resolve project path: %w", cErr)
 		}
-		workspace := wiring.NewWorkspace(cwd)
+		workspace, wsErr := wiring.NewWorkspaceForProject(cwd, currentSubProject())
+		if wsErr != nil {
+			return fmt.Errorf("resolve workspace: %w", wsErr)
+		}
 		repo := workspace.Repo
 		audit := workspace.Audit
 		service := application.NewInitService(repo, audit)
@@ -28,6 +31,10 @@ var initCmd = &cobra.Command{
 		projectName := "new-project"
 		if len(args) > 0 {
 			projectName = args[0]
+		} else if sub := currentSubProject(); sub != "" {
+			// Default a sub-project's display name to its directory slug
+			// when the caller did not pass an explicit name.
+			projectName = sub
 		}
 
 		if shouldRunInteractive() {

--- a/internal/infrastructure/cli/root.go
+++ b/internal/infrastructure/cli/root.go
@@ -13,6 +13,10 @@ var (
 	Commit      = "none"
 	Date        = "unknown"
 	projectPath string
+	// subProjectFlag scopes commands to a named sub-project under
+	// <root>/.roady/projects/<name>/. Empty = the root project.
+	// Falls back to the ROADY_PROJECT environment variable when not set.
+	subProjectFlag string
 )
 
 // RootCmd represents the base command when called without any subcommands
@@ -54,4 +58,6 @@ func Execute() error {
 func init() {
 	RootCmd.PersistentFlags().StringVarP(&projectPath, "path", "C", "",
 		"Path to the roady project directory (defaults to current directory)")
+	RootCmd.PersistentFlags().StringVarP(&subProjectFlag, "project", "P", "",
+		"Sub-project name under .roady/projects/<name>/ (defaults to ROADY_PROJECT env or root project)")
 }

--- a/internal/infrastructure/cli/services.go
+++ b/internal/infrastructure/cli/services.go
@@ -9,7 +9,11 @@ import (
 )
 
 func loadServices(root string) (*wiring.AppServices, error) {
-	services, loadErr := wiring.BuildAppServices(root)
+	return loadServicesForProject(root, currentSubProject())
+}
+
+func loadServicesForProject(root, project string) (*wiring.AppServices, error) {
+	services, loadErr := wiring.BuildAppServicesForProject(root, project)
 	if services == nil {
 		return nil, fmt.Errorf("failed to build services: %w", loadErr)
 	}
@@ -17,6 +21,16 @@ func loadServices(root string) (*wiring.AppServices, error) {
 		fmt.Printf("Warning: %v\n", loadErr)
 	}
 	return services, nil
+}
+
+// currentSubProject resolves the active sub-project name from the --project
+// flag, falling back to the ROADY_PROJECT environment variable. Empty string
+// means the root project.
+func currentSubProject() string {
+	if subProjectFlag != "" {
+		return subProjectFlag
+	}
+	return os.Getenv("ROADY_PROJECT")
 }
 
 func getProjectRoot() (string, error) {
@@ -42,5 +56,5 @@ func loadServicesForCurrentDir() (*wiring.AppServices, error) {
 	if err != nil {
 		return nil, err
 	}
-	return loadServices(root)
+	return loadServicesForProject(root, currentSubProject())
 }

--- a/internal/infrastructure/mcp/handlers_v070.go
+++ b/internal/infrastructure/mcp/handlers_v070.go
@@ -10,6 +10,7 @@ import (
 // Org policy handler
 type OrgPolicyArgs struct {
 	ProjectPath string `json:"project_path,omitempty" jsonschema:"description=Path to the project (default: current directory)"`
+	Project     string `json:"project,omitempty" jsonschema:"description=Sub-project name under .roady/projects/<name>/ (default: root project)"`
 }
 
 func (s *Server) handleOrgPolicy(ctx context.Context, args OrgPolicyArgs) (any, error) {
@@ -36,11 +37,11 @@ func (s *Server) handleOrgDetectDrift(ctx context.Context, args GetSpecArgs) (an
 
 // Plugin handlers
 
-func (s *Server) pluginSvcForPath(projectPath string) *application.PluginService {
-	if projectPath == "" || projectPath == s.root {
+func (s *Server) pluginSvcForPath(projectPath, project string) *application.PluginService {
+	if (projectPath == "" || projectPath == s.root) && project == "" {
 		return s.pluginSvc
 	}
-	svc, err := s.servicesForPath(projectPath)
+	svc, err := s.servicesForPath(projectPath, project)
 	if err != nil {
 		return s.pluginSvc
 	}
@@ -48,7 +49,7 @@ func (s *Server) pluginSvcForPath(projectPath string) *application.PluginService
 }
 
 func (s *Server) handlePluginList(ctx context.Context, args GetSpecArgs) (any, error) {
-	plugins, err := s.pluginSvcForPath(args.ProjectPath).ListPlugins()
+	plugins, err := s.pluginSvcForPath(args.ProjectPath, args.Project).ListPlugins()
 	if err != nil {
 		return nil, mcpErr("Failed to list plugins.")
 	}
@@ -58,10 +59,11 @@ func (s *Server) handlePluginList(ctx context.Context, args GetSpecArgs) (any, e
 type PluginValidateArgs struct {
 	Name        string `json:"name" jsonschema:"description=Name of the plugin to validate"`
 	ProjectPath string `json:"project_path,omitempty" jsonschema:"description=Path to the roady project directory (default: server root)"`
+	Project     string `json:"project,omitempty" jsonschema:"description=Sub-project name under .roady/projects/<name>/ (default: root project)"`
 }
 
 func (s *Server) handlePluginValidate(ctx context.Context, args PluginValidateArgs) (any, error) {
-	result, err := s.pluginSvcForPath(args.ProjectPath).ValidatePlugin(args.Name)
+	result, err := s.pluginSvcForPath(args.ProjectPath, args.Project).ValidatePlugin(args.Name)
 	if err != nil {
 		return nil, mcpErr("Failed to validate plugin.")
 	}
@@ -71,10 +73,11 @@ func (s *Server) handlePluginValidate(ctx context.Context, args PluginValidateAr
 type PluginStatusArgs struct {
 	Name        string `json:"name,omitempty" jsonschema:"description=Name of the plugin to check (omit for all)"`
 	ProjectPath string `json:"project_path,omitempty" jsonschema:"description=Path to the roady project directory (default: server root)"`
+	Project     string `json:"project,omitempty" jsonschema:"description=Sub-project name under .roady/projects/<name>/ (default: root project)"`
 }
 
 func (s *Server) handlePluginStatus(ctx context.Context, args PluginStatusArgs) (any, error) {
-	psvc := s.pluginSvcForPath(args.ProjectPath)
+	psvc := s.pluginSvcForPath(args.ProjectPath, args.Project)
 	if args.Name != "" {
 		result, err := psvc.CheckHealth(args.Name)
 		if err != nil {

--- a/internal/infrastructure/mcp/server.go
+++ b/internal/infrastructure/mcp/server.go
@@ -103,12 +103,17 @@ func capSlice(s []string) []string {
 	return s
 }
 
-// servicesForPath returns the default services for the server root,
-// or builds a fresh set of services for the given override path.
+// servicesForPath returns services for the requested project scope.
+// When pathOverride is empty (or matches the server root) AND project is empty,
+// the server's default services are returned. Otherwise a fresh AppServices set
+// is built and cached per (path, project) key — sub-projects under the same
+// repo get their own cached entries.
+//
 // Cross-project services are cached to avoid rebuilding the full stack
 // (event replay, AI config loading, etc.) on every request.
-func (s *Server) servicesForPath(override string) (*wiring.AppServices, error) {
-	if override == "" || override == s.root {
+func (s *Server) servicesForPath(pathOverride, project string) (*wiring.AppServices, error) {
+	usingDefault := (pathOverride == "" || pathOverride == s.root) && project == ""
+	if usingDefault {
 		if s.services != nil {
 			return s.services, nil
 		}
@@ -132,19 +137,25 @@ func (s *Server) servicesForPath(override string) (*wiring.AppServices, error) {
 		}, nil
 	}
 
+	root := pathOverride
+	if root == "" {
+		root = s.root
+	}
+	cacheKey := root + "\x00" + project
+
 	// Check cache first.
-	if cached, ok := s.svcCache.Load(override); ok {
+	if cached, ok := s.svcCache.Load(cacheKey); ok {
 		return cached.(*wiring.AppServices), nil
 	}
 
 	// Build fresh services (expensive — involves event replay, AI config, etc.).
-	svc, err := wiring.BuildAppServices(override)
+	svc, err := wiring.BuildAppServicesForProject(root, project)
 	if err != nil && svc == nil {
 		return nil, err
 	}
 
 	// Atomically store; if another goroutine raced us, use theirs.
-	if existing, loaded := s.svcCache.LoadOrStore(override, svc); loaded {
+	if existing, loaded := s.svcCache.LoadOrStore(cacheKey, svc); loaded {
 		return existing.(*wiring.AppServices), nil
 	}
 
@@ -155,7 +166,7 @@ func (s *Server) servicesForPath(override string) (*wiring.AppServices, error) {
 		s.svcKeys = s.svcKeys[1:]
 		s.svcCache.Delete(evict)
 	}
-	s.svcKeys = append(s.svcKeys, override)
+	s.svcKeys = append(s.svcKeys, cacheKey)
 	s.svcCacheMu.Unlock()
 
 	return svc, nil
@@ -213,89 +224,110 @@ func NewServer(root string) (*Server, error) {
 type InitArgs struct {
 	Name        string `json:"name" jsonschema:"description=The name of the project"`
 	ProjectPath string `json:"project_path,omitempty" jsonschema:"description=Path to the roady project directory (default: server root)"`
+	Project     string `json:"project,omitempty" jsonschema:"description=Sub-project name under .roady/projects/<name>/ (default: root project)"`
 }
 
 type UpdatePlanArgs struct {
 	Tasks       []planning.Task `json:"tasks" jsonschema:"description=The list of tasks to define the plan"`
 	ProjectPath string          `json:"project_path,omitempty" jsonschema:"description=Path to the roady project directory (default: server root)"`
+	Project     string `json:"project,omitempty" jsonschema:"description=Sub-project name under .roady/projects/<name>/ (default: root project)"`
 }
 
 // Args structs for handlers that previously used struct{}
 
 type GetSpecArgs struct {
 	ProjectPath string `json:"project_path,omitempty" jsonschema:"description=Path to the roady project directory (default: server root)"`
+	Project     string `json:"project,omitempty" jsonschema:"description=Sub-project name under .roady/projects/<name>/ (default: root project)"`
 }
 
 type GetPlanArgs struct {
 	ProjectPath string `json:"project_path,omitempty" jsonschema:"description=Path to the roady project directory (default: server root)"`
+	Project     string `json:"project,omitempty" jsonschema:"description=Sub-project name under .roady/projects/<name>/ (default: root project)"`
 }
 
 type GetStateArgs struct {
 	ProjectPath string `json:"project_path,omitempty" jsonschema:"description=Path to the roady project directory (default: server root)"`
+	Project     string `json:"project,omitempty" jsonschema:"description=Sub-project name under .roady/projects/<name>/ (default: root project)"`
 }
 
 type GeneratePlanArgs struct {
 	ProjectPath string `json:"project_path,omitempty" jsonschema:"description=Path to the roady project directory (default: server root)"`
+	Project     string `json:"project,omitempty" jsonschema:"description=Sub-project name under .roady/projects/<name>/ (default: root project)"`
 }
 
 type DetectDriftArgs struct {
 	ProjectPath string `json:"project_path,omitempty" jsonschema:"description=Path to the roady project directory (default: server root)"`
+	Project     string `json:"project,omitempty" jsonschema:"description=Sub-project name under .roady/projects/<name>/ (default: root project)"`
 }
 
 type ApprovePlanArgs struct {
 	ProjectPath string `json:"project_path,omitempty" jsonschema:"description=Path to the roady project directory (default: server root)"`
+	Project     string `json:"project,omitempty" jsonschema:"description=Sub-project name under .roady/projects/<name>/ (default: root project)"`
 }
 
 type ExplainSpecArgs struct {
 	ProjectPath string `json:"project_path,omitempty" jsonschema:"description=Path to the roady project directory (default: server root)"`
+	Project     string `json:"project,omitempty" jsonschema:"description=Sub-project name under .roady/projects/<name>/ (default: root project)"`
 }
 
 type ExplainDriftArgs struct {
 	ProjectPath string `json:"project_path,omitempty" jsonschema:"description=Path to the roady project directory (default: server root)"`
+	Project     string `json:"project,omitempty" jsonschema:"description=Sub-project name under .roady/projects/<name>/ (default: root project)"`
 }
 
 type AcceptDriftArgs struct {
 	ProjectPath string `json:"project_path,omitempty" jsonschema:"description=Path to the roady project directory (default: server root)"`
+	Project     string `json:"project,omitempty" jsonschema:"description=Sub-project name under .roady/projects/<name>/ (default: root project)"`
 }
 
 type GetUsageArgs struct {
 	ProjectPath string `json:"project_path,omitempty" jsonschema:"description=Path to the roady project directory (default: server root)"`
+	Project     string `json:"project,omitempty" jsonschema:"description=Sub-project name under .roady/projects/<name>/ (default: root project)"`
 }
 
 type CheckPolicyArgs struct {
 	ProjectPath string `json:"project_path,omitempty" jsonschema:"description=Path to the roady project directory (default: server root)"`
+	Project     string `json:"project,omitempty" jsonschema:"description=Sub-project name under .roady/projects/<name>/ (default: root project)"`
 }
 
 type ForecastArgs struct {
 	ProjectPath string `json:"project_path,omitempty" jsonschema:"description=Path to the roady project directory (default: server root)"`
+	Project     string `json:"project,omitempty" jsonschema:"description=Sub-project name under .roady/projects/<name>/ (default: root project)"`
 }
 
 type GitSyncArgs struct {
 	ProjectPath string `json:"project_path,omitempty" jsonschema:"description=Path to the roady project directory (default: server root)"`
+	Project     string `json:"project,omitempty" jsonschema:"description=Sub-project name under .roady/projects/<name>/ (default: root project)"`
 }
 
 type SuggestPrioritiesArgs struct {
 	ProjectPath string `json:"project_path,omitempty" jsonschema:"description=Path to the roady project directory (default: server root)"`
+	Project     string `json:"project,omitempty" jsonschema:"description=Sub-project name under .roady/projects/<name>/ (default: root project)"`
 }
 
 type ReviewSpecArgs struct {
 	ProjectPath string `json:"project_path,omitempty" jsonschema:"description=Path to the roady project directory (default: server root)"`
+	Project     string `json:"project,omitempty" jsonschema:"description=Sub-project name under .roady/projects/<name>/ (default: root project)"`
 }
 
 type GetSnapshotArgs struct {
 	ProjectPath string `json:"project_path,omitempty" jsonschema:"description=Path to the roady project directory (default: server root)"`
+	Project     string `json:"project,omitempty" jsonschema:"description=Sub-project name under .roady/projects/<name>/ (default: root project)"`
 }
 
 type GetReadyTasksArgs struct {
 	ProjectPath string `json:"project_path,omitempty" jsonschema:"description=Path to the roady project directory (default: server root)"`
+	Project     string `json:"project,omitempty" jsonschema:"description=Sub-project name under .roady/projects/<name>/ (default: root project)"`
 }
 
 type GetBlockedTasksArgs struct {
 	ProjectPath string `json:"project_path,omitempty" jsonschema:"description=Path to the roady project directory (default: server root)"`
+	Project     string `json:"project,omitempty" jsonschema:"description=Sub-project name under .roady/projects/<name>/ (default: root project)"`
 }
 
 type GetInProgressTasksArgs struct {
 	ProjectPath string `json:"project_path,omitempty" jsonschema:"description=Path to the roady project directory (default: server root)"`
+	Project     string `json:"project,omitempty" jsonschema:"description=Sub-project name under .roady/projects/<name>/ (default: root project)"`
 }
 
 // TasksArgs supersedes the three legacy roady_get_*_tasks tools by adding a
@@ -304,6 +336,7 @@ type GetInProgressTasksArgs struct {
 type TasksArgs struct {
 	Status      string `json:"status,omitempty" jsonschema:"description=Which tasks to return: ready (unlocked + pending), in_progress, blocked, or all. Defaults to ready.,enum=ready,enum=in_progress,enum=blocked,enum=all"`
 	ProjectPath string `json:"project_path,omitempty" jsonschema:"description=Path to the roady project directory (default: server root)"`
+	Project     string `json:"project,omitempty" jsonschema:"description=Sub-project name under .roady/projects/<name>/ (default: root project)"`
 }
 
 // CostEstimateArgs are the inputs for roady_cost_estimate. Operation defaults
@@ -312,23 +345,28 @@ type TasksArgs struct {
 type CostEstimateArgs struct {
 	Operation   string `json:"operation,omitempty" jsonschema:"description=AI operation to estimate. Defaults to generate_plan.,enum=generate_plan,enum=smart_decompose,enum=review_spec,enum=explain_drift,enum=query"`
 	ProjectPath string `json:"project_path,omitempty" jsonschema:"description=Path to the roady project directory (default: server root)"`
+	Project     string `json:"project,omitempty" jsonschema:"description=Sub-project name under .roady/projects/<name>/ (default: root project)"`
 }
 
 type SmartDecomposeArgs struct {
 	ProjectPath string `json:"project_path,omitempty" jsonschema:"description=Path to the roady project directory (default: server root)"`
+	Project     string `json:"project,omitempty" jsonschema:"description=Sub-project name under .roady/projects/<name>/ (default: root project)"`
 }
 
 type WorkspacePushArgs struct {
 	ProjectPath string `json:"project_path,omitempty" jsonschema:"description=Path to the roady project directory (default: server root)"`
+	Project     string `json:"project,omitempty" jsonschema:"description=Sub-project name under .roady/projects/<name>/ (default: root project)"`
 }
 
 type WorkspacePullArgs struct {
 	ProjectPath string `json:"project_path,omitempty" jsonschema:"description=Path to the roady project directory (default: server root)"`
+	Project     string `json:"project,omitempty" jsonschema:"description=Sub-project name under .roady/projects/<name>/ (default: root project)"`
 }
 
 type SyncArgs struct {
 	PluginPath  string `json:"plugin_path" jsonschema:"description=Path to the syncer plugin binary"`
 	ProjectPath string `json:"project_path,omitempty" jsonschema:"description=Path to the roady project directory (default: server root)"`
+	Project     string `json:"project,omitempty" jsonschema:"description=Sub-project name under .roady/projects/<name>/ (default: root project)"`
 }
 
 func (s *Server) registerTools() {
@@ -693,7 +731,7 @@ func (s *Server) registerTools() {
 }
 
 func (s *Server) handleForecast(ctx context.Context, args ForecastArgs) (any, error) {
-	svc, err := s.servicesForPath(args.ProjectPath)
+	svc, err := s.servicesForPath(args.ProjectPath, args.Project)
 	if err != nil {
 		return nil, mcpErr("Failed to load project at the given path.")
 	}
@@ -782,7 +820,7 @@ func (s *Server) handleOrgStatus(ctx context.Context, args GetSpecArgs) (any, er
 }
 
 func (s *Server) handleGitSync(ctx context.Context, args GitSyncArgs) (any, error) {
-	svc, err := s.servicesForPath(args.ProjectPath)
+	svc, err := s.servicesForPath(args.ProjectPath, args.Project)
 	if err != nil {
 		return nil, mcpErr("Failed to load project at the given path.")
 	}
@@ -794,7 +832,7 @@ func (s *Server) handleGitSync(ctx context.Context, args GitSyncArgs) (any, erro
 }
 
 func (s *Server) handleSync(ctx context.Context, args SyncArgs) (any, error) {
-	svc, err := s.servicesForPath(args.ProjectPath)
+	svc, err := s.servicesForPath(args.ProjectPath, args.Project)
 	if err != nil {
 		return nil, mcpErr("Failed to load project at the given path.")
 	}
@@ -806,7 +844,7 @@ func (s *Server) handleSync(ctx context.Context, args SyncArgs) (any, error) {
 }
 
 func (s *Server) handleExplainDrift(ctx context.Context, args ExplainDriftArgs) (string, error) {
-	svc, err := s.servicesForPath(args.ProjectPath)
+	svc, err := s.servicesForPath(args.ProjectPath, args.Project)
 	if err != nil {
 		return "", mcpErr("Failed to load project at the given path.")
 	}
@@ -826,7 +864,7 @@ func (s *Server) handleExplainDrift(ctx context.Context, args ExplainDriftArgs) 
 }
 
 func (s *Server) handleAcceptDrift(ctx context.Context, args AcceptDriftArgs) (string, error) {
-	svc, err := s.servicesForPath(args.ProjectPath)
+	svc, err := s.servicesForPath(args.ProjectPath, args.Project)
 	if err != nil {
 		return "", mcpErr("Failed to load project at the given path.")
 	}
@@ -840,10 +878,11 @@ type AddFeatureArgs struct {
 	Title       string `json:"title" jsonschema:"description=The title of the new feature"`
 	Description string `json:"description" jsonschema:"description=A detailed description of the feature"`
 	ProjectPath string `json:"project_path,omitempty" jsonschema:"description=Path to the roady project directory (default: server root)"`
+	Project     string `json:"project,omitempty" jsonschema:"description=Sub-project name under .roady/projects/<name>/ (default: root project)"`
 }
 
 func (s *Server) handleAddFeature(ctx context.Context, args AddFeatureArgs) (string, error) {
-	svc, err := s.servicesForPath(args.ProjectPath)
+	svc, err := s.servicesForPath(args.ProjectPath, args.Project)
 	if err != nil {
 		return "", mcpErr("Failed to load project at the given path.")
 	}
@@ -855,7 +894,7 @@ func (s *Server) handleAddFeature(ctx context.Context, args AddFeatureArgs) (str
 }
 
 func (s *Server) handleGetUsage(ctx context.Context, args GetUsageArgs) (any, error) {
-	svc, err := s.servicesForPath(args.ProjectPath)
+	svc, err := s.servicesForPath(args.ProjectPath, args.Project)
 	if err != nil {
 		return nil, mcpErr("Failed to load project at the given path.")
 	}
@@ -867,7 +906,7 @@ func (s *Server) handleGetUsage(ctx context.Context, args GetUsageArgs) (any, er
 }
 
 func (s *Server) handleApprovePlan(ctx context.Context, args ApprovePlanArgs) (string, error) {
-	svc, err := s.servicesForPath(args.ProjectPath)
+	svc, err := s.servicesForPath(args.ProjectPath, args.Project)
 	if err != nil {
 		return "", mcpErr("Failed to load project at the given path.")
 	}
@@ -879,7 +918,7 @@ func (s *Server) handleApprovePlan(ctx context.Context, args ApprovePlanArgs) (s
 }
 
 func (s *Server) handleExplainSpec(ctx context.Context, args ExplainSpecArgs) (string, error) {
-	svc, err := s.servicesForPath(args.ProjectPath)
+	svc, err := s.servicesForPath(args.ProjectPath, args.Project)
 	if err != nil {
 		return "", mcpErr("Failed to load project at the given path.")
 	}
@@ -897,13 +936,14 @@ func (s *Server) handleExplainSpec(ctx context.Context, args ExplainSpecArgs) (s
 type QueryArgs struct {
 	Question    string `json:"question" jsonschema:"description=A natural language question about the project"`
 	ProjectPath string `json:"project_path,omitempty" jsonschema:"description=Path to the roady project directory (default: server root)"`
+	Project     string `json:"project,omitempty" jsonschema:"description=Sub-project name under .roady/projects/<name>/ (default: root project)"`
 }
 
 func (s *Server) handleQuery(ctx context.Context, args QueryArgs) (string, error) {
 	if args.Question == "" {
 		return "", mcpErr("A question is required.")
 	}
-	svc, err := s.servicesForPath(args.ProjectPath)
+	svc, err := s.servicesForPath(args.ProjectPath, args.Project)
 	if err != nil {
 		return "", mcpErr("Failed to load project at the given path.")
 	}
@@ -919,7 +959,7 @@ func (s *Server) handleQuery(ctx context.Context, args QueryArgs) (string, error
 }
 
 func (s *Server) handleSuggestPriorities(ctx context.Context, args SuggestPrioritiesArgs) (any, error) {
-	svc, err := s.servicesForPath(args.ProjectPath)
+	svc, err := s.servicesForPath(args.ProjectPath, args.Project)
 	if err != nil {
 		return nil, mcpErr("Failed to load project at the given path.")
 	}
@@ -935,7 +975,7 @@ func (s *Server) handleSuggestPriorities(ctx context.Context, args SuggestPriori
 }
 
 func (s *Server) handleReviewSpec(ctx context.Context, args ReviewSpecArgs) (any, error) {
-	svc, err := s.servicesForPath(args.ProjectPath)
+	svc, err := s.servicesForPath(args.ProjectPath, args.Project)
 	if err != nil {
 		return nil, mcpErr("Failed to load project at the given path.")
 	}
@@ -956,12 +996,14 @@ type TransitionTaskArgs struct {
 	Evidence    string `json:"evidence,omitempty" jsonschema:"description=Optional evidence for the transition (e.g. commit hash)"`
 	Actor       string `json:"actor,omitempty" jsonschema:"description=The actor performing the transition (defaults to ai-agent)"`
 	ProjectPath string `json:"project_path,omitempty" jsonschema:"description=Path to the roady project directory (default: server root)"`
+	Project     string `json:"project,omitempty" jsonschema:"description=Sub-project name under .roady/projects/<name>/ (default: root project)"`
 }
 
 type AssignTaskArgs struct {
 	TaskID      string `json:"task_id" jsonschema:"description=The ID of the task to assign"`
 	Assignee    string `json:"assignee" jsonschema:"description=The person or agent to assign the task to"`
 	ProjectPath string `json:"project_path,omitempty" jsonschema:"description=Path to the roady project directory (default: server root)"`
+	Project     string `json:"project,omitempty" jsonschema:"description=Sub-project name under .roady/projects/<name>/ (default: root project)"`
 }
 
 // FlexBool accepts both boolean and string ("true"/"false") JSON values.
@@ -1014,10 +1056,11 @@ type StatusArgs struct {
 	Limit       FlexInt  `json:"limit,omitempty" jsonschema:"description=Limit number of tasks returned"`
 	JSON        FlexBool `json:"json,omitempty" jsonschema:"description=Return structured JSON output instead of text"`
 	ProjectPath string   `json:"project_path,omitempty" jsonschema:"description=Path to the roady project directory (default: server root)"`
+	Project     string `json:"project,omitempty" jsonschema:"description=Sub-project name under .roady/projects/<name>/ (default: root project)"`
 }
 
 func (s *Server) handleAssignTask(ctx context.Context, args AssignTaskArgs) (string, error) {
-	svc, err := s.servicesForPath(args.ProjectPath)
+	svc, err := s.servicesForPath(args.ProjectPath, args.Project)
 	if err != nil {
 		return "", mcpErr("Failed to load project at the given path.")
 	}
@@ -1029,7 +1072,7 @@ func (s *Server) handleAssignTask(ctx context.Context, args AssignTaskArgs) (str
 }
 
 func (s *Server) handleTransitionTask(ctx context.Context, args TransitionTaskArgs) (string, error) {
-	svc, err := s.servicesForPath(args.ProjectPath)
+	svc, err := s.servicesForPath(args.ProjectPath, args.Project)
 	if err != nil {
 		return "", mcpErr("Failed to load project at the given path.")
 	}
@@ -1045,7 +1088,7 @@ func (s *Server) handleTransitionTask(ctx context.Context, args TransitionTaskAr
 }
 
 func (s *Server) handleInit(ctx context.Context, args InitArgs) (string, error) {
-	svc, err := s.servicesForPath(args.ProjectPath)
+	svc, err := s.servicesForPath(args.ProjectPath, args.Project)
 	if err != nil {
 		return "", mcpErr("Failed to load project at the given path.")
 	}
@@ -1057,7 +1100,7 @@ func (s *Server) handleInit(ctx context.Context, args InitArgs) (string, error) 
 }
 
 func (s *Server) handleGetSpec(ctx context.Context, args GetSpecArgs) (any, error) {
-	svc, err := s.servicesForPath(args.ProjectPath)
+	svc, err := s.servicesForPath(args.ProjectPath, args.Project)
 	if err != nil {
 		return nil, mcpErr("Failed to load project at the given path.")
 	}
@@ -1069,7 +1112,7 @@ func (s *Server) handleGetSpec(ctx context.Context, args GetSpecArgs) (any, erro
 }
 
 func (s *Server) handleGetPlan(ctx context.Context, args GetPlanArgs) (any, error) {
-	svc, err := s.servicesForPath(args.ProjectPath)
+	svc, err := s.servicesForPath(args.ProjectPath, args.Project)
 	if err != nil {
 		return nil, mcpErr("Failed to load project at the given path.")
 	}
@@ -1081,7 +1124,7 @@ func (s *Server) handleGetPlan(ctx context.Context, args GetPlanArgs) (any, erro
 }
 
 func (s *Server) handleGetState(ctx context.Context, args GetStateArgs) (any, error) {
-	svc, err := s.servicesForPath(args.ProjectPath)
+	svc, err := s.servicesForPath(args.ProjectPath, args.Project)
 	if err != nil {
 		return nil, mcpErr("Failed to load project at the given path.")
 	}
@@ -1093,7 +1136,7 @@ func (s *Server) handleGetState(ctx context.Context, args GetStateArgs) (any, er
 }
 
 func (s *Server) handleGeneratePlan(ctx context.Context, args GeneratePlanArgs) (string, error) {
-	svc, err := s.servicesForPath(args.ProjectPath)
+	svc, err := s.servicesForPath(args.ProjectPath, args.Project)
 	if err != nil {
 		return "", mcpErr("Failed to load project at the given path.")
 	}
@@ -1105,7 +1148,7 @@ func (s *Server) handleGeneratePlan(ctx context.Context, args GeneratePlanArgs) 
 }
 
 func (s *Server) handleUpdatePlan(ctx context.Context, args UpdatePlanArgs) (string, error) {
-	svc, err := s.servicesForPath(args.ProjectPath)
+	svc, err := s.servicesForPath(args.ProjectPath, args.Project)
 	if err != nil {
 		return "", mcpErr("Failed to load project at the given path.")
 	}
@@ -1117,7 +1160,7 @@ func (s *Server) handleUpdatePlan(ctx context.Context, args UpdatePlanArgs) (str
 }
 
 func (s *Server) handleDetectDrift(ctx context.Context, args DetectDriftArgs) (any, error) {
-	svc, err := s.servicesForPath(args.ProjectPath)
+	svc, err := s.servicesForPath(args.ProjectPath, args.Project)
 	if err != nil {
 		return nil, mcpErr("Failed to load project at the given path.")
 	}
@@ -1129,7 +1172,7 @@ func (s *Server) handleDetectDrift(ctx context.Context, args DetectDriftArgs) (a
 }
 
 func (s *Server) handleStatus(ctx context.Context, args StatusArgs) (any, error) {
-	svc, err := s.servicesForPath(args.ProjectPath)
+	svc, err := s.servicesForPath(args.ProjectPath, args.Project)
 	if err != nil {
 		return nil, mcpErr("Failed to load project at the given path.")
 	}
@@ -1320,7 +1363,7 @@ func containsPriority(priorities []planning.TaskPriority, p planning.TaskPriorit
 }
 
 func (s *Server) handleCheckPolicy(ctx context.Context, args CheckPolicyArgs) (any, error) {
-	svc, err := s.servicesForPath(args.ProjectPath)
+	svc, err := s.servicesForPath(args.ProjectPath, args.Project)
 	if err != nil {
 		return nil, mcpErr("Failed to load project at the given path.")
 	}
@@ -1478,7 +1521,7 @@ func (s *Server) handleDebtTrend(ctx context.Context, args DebtTrendArgs) (any, 
 // Coordinator-based snapshot and task query handlers (v0.6.0)
 
 func (s *Server) handleGetSnapshot(ctx context.Context, args GetSnapshotArgs) (any, error) {
-	svc, err := s.servicesForPath(args.ProjectPath)
+	svc, err := s.servicesForPath(args.ProjectPath, args.Project)
 	if err != nil {
 		return nil, mcpErr("Failed to load project at the given path.")
 	}
@@ -1520,7 +1563,7 @@ func (s *Server) handleGetSnapshot(ctx context.Context, args GetSnapshotArgs) (a
 // read from .roady/ai.yaml and overridden by env vars at provider load time;
 // here we only need provider/model identifiers, not a live provider.
 func (s *Server) handleCostEstimate(ctx context.Context, args CostEstimateArgs) (any, error) {
-	svc, err := s.servicesForPath(args.ProjectPath)
+	svc, err := s.servicesForPath(args.ProjectPath, args.Project)
 	if err != nil {
 		return nil, mcpErr("Failed to load project at the given path.")
 	}
@@ -1569,7 +1612,7 @@ type domainProviderLike interface {
 // The legacy per-status handlers below delegate to it so the response shape
 // stays identical and a single code path serves both old and new tool names.
 func (s *Server) handleTasks(ctx context.Context, args TasksArgs) (any, error) {
-	svc, err := s.servicesForPath(args.ProjectPath)
+	svc, err := s.servicesForPath(args.ProjectPath, args.Project)
 	if err != nil {
 		return nil, mcpErr("Failed to load project at the given path.")
 	}
@@ -1639,7 +1682,7 @@ func (s *Server) handleWorkspacePush(ctx context.Context, args WorkspacePushArgs
 	root := s.root
 	auditSvc := s.auditSvc
 	if args.ProjectPath != "" && args.ProjectPath != s.root {
-		overrideSvc, err := s.servicesForPath(args.ProjectPath)
+		overrideSvc, err := s.servicesForPath(args.ProjectPath, args.Project)
 		if err != nil {
 			return nil, mcpErr("Failed to load project at the given path.")
 		}
@@ -1658,7 +1701,7 @@ func (s *Server) handleWorkspacePull(ctx context.Context, args WorkspacePullArgs
 	root := s.root
 	auditSvc := s.auditSvc
 	if args.ProjectPath != "" && args.ProjectPath != s.root {
-		overrideSvc, err := s.servicesForPath(args.ProjectPath)
+		overrideSvc, err := s.servicesForPath(args.ProjectPath, args.Project)
 		if err != nil {
 			return nil, mcpErr("Failed to load project at the given path.")
 		}
@@ -1676,7 +1719,7 @@ func (s *Server) handleWorkspacePull(ctx context.Context, args WorkspacePullArgs
 // --- Smart Decompose Handler ---
 
 func (s *Server) handleSmartDecompose(ctx context.Context, args SmartDecomposeArgs) (any, error) {
-	svc, err := s.servicesForPath(args.ProjectPath)
+	svc, err := s.servicesForPath(args.ProjectPath, args.Project)
 	if err != nil {
 		return nil, mcpErr("Failed to load project at the given path.")
 	}
@@ -1701,15 +1744,17 @@ type TeamAddArgs struct {
 	Name        string `json:"name" jsonschema:"description=The name of the team member"`
 	Role        string `json:"role" jsonschema:"description=The role: admin, member, or viewer"`
 	ProjectPath string `json:"project_path,omitempty" jsonschema:"description=Path to the roady project directory (default: server root)"`
+	Project     string `json:"project,omitempty" jsonschema:"description=Sub-project name under .roady/projects/<name>/ (default: root project)"`
 }
 
 type TeamRemoveArgs struct {
 	Name        string `json:"name" jsonschema:"description=The name of the team member to remove"`
 	ProjectPath string `json:"project_path,omitempty" jsonschema:"description=Path to the roady project directory (default: server root)"`
+	Project     string `json:"project,omitempty" jsonschema:"description=Sub-project name under .roady/projects/<name>/ (default: root project)"`
 }
 
 func (s *Server) handleTeamList(ctx context.Context, args GetSpecArgs) (any, error) {
-	svc, err := s.servicesForPath(args.ProjectPath)
+	svc, err := s.servicesForPath(args.ProjectPath, args.Project)
 	if err != nil {
 		return nil, mcpErr("Failed to load project at the given path.")
 	}
@@ -1727,7 +1772,7 @@ func (s *Server) handleTeamAdd(ctx context.Context, args TeamAddArgs) (string, e
 	if args.Role == "" {
 		return "", mcpErr("role is required")
 	}
-	svc, err := s.servicesForPath(args.ProjectPath)
+	svc, err := s.servicesForPath(args.ProjectPath, args.Project)
 	if err != nil {
 		return "", mcpErr("Failed to load project at the given path.")
 	}
@@ -1741,7 +1786,7 @@ func (s *Server) handleTeamRemove(ctx context.Context, args TeamRemoveArgs) (str
 	if args.Name == "" {
 		return "", mcpErr("name is required")
 	}
-	svc, err := s.servicesForPath(args.ProjectPath)
+	svc, err := s.servicesForPath(args.ProjectPath, args.Project)
 	if err != nil {
 		return "", mcpErr("Failed to load project at the given path.")
 	}
@@ -1753,10 +1798,11 @@ func (s *Server) handleTeamRemove(ctx context.Context, args TeamRemoveArgs) (str
 
 type RateListArgs struct {
 	ProjectPath string `json:"project_path,omitempty" jsonschema:"description=Path to the roady project directory (default: server root)"`
+	Project     string `json:"project,omitempty" jsonschema:"description=Sub-project name under .roady/projects/<name>/ (default: root project)"`
 }
 
 func (s *Server) handleRateList(ctx context.Context, args RateListArgs) (any, error) {
-	svc, err := s.servicesForPath(args.ProjectPath)
+	svc, err := s.servicesForPath(args.ProjectPath, args.Project)
 	if err != nil {
 		return nil, mcpErr("Failed to load project at the given path.")
 	}
@@ -1773,13 +1819,14 @@ type RateAddArgs struct {
 	HourlyRate  float64 `json:"hourly_rate" jsonschema:"description=Hourly rate amount"`
 	IsDefault   bool    `json:"is_default" jsonschema:"description=Set as default rate"`
 	ProjectPath string  `json:"project_path,omitempty" jsonschema:"description=Path to the roady project directory (default: server root)"`
+	Project     string `json:"project,omitempty" jsonschema:"description=Sub-project name under .roady/projects/<name>/ (default: root project)"`
 }
 
 func (s *Server) handleRateAdd(ctx context.Context, args RateAddArgs) (string, error) {
 	if args.ID == "" || args.Name == "" {
 		return "", mcpErr("id and name are required")
 	}
-	svc, err := s.servicesForPath(args.ProjectPath)
+	svc, err := s.servicesForPath(args.ProjectPath, args.Project)
 	if err != nil {
 		return "", mcpErr("Failed to load project at the given path.")
 	}
@@ -1801,13 +1848,14 @@ type TaskLogTimeArgs struct {
 	RateID      string `json:"rate_id" jsonschema:"description=Rate ID (optional)"`
 	Description string `json:"description" jsonschema:"description=Description (optional)"`
 	ProjectPath string `json:"project_path,omitempty" jsonschema:"description=Path to the roady project directory (default: server root)"`
+	Project     string `json:"project,omitempty" jsonschema:"description=Sub-project name under .roady/projects/<name>/ (default: root project)"`
 }
 
 func (s *Server) handleTaskLogTime(ctx context.Context, args TaskLogTimeArgs) (string, error) {
 	if args.TaskID == "" || args.Minutes <= 0 {
 		return "", mcpErr("task_id and minutes are required")
 	}
-	svc, err := s.servicesForPath(args.ProjectPath)
+	svc, err := s.servicesForPath(args.ProjectPath, args.Project)
 	if err != nil {
 		return "", mcpErr("Failed to load project at the given path.")
 	}
@@ -1822,10 +1870,11 @@ type CostReportArgs struct {
 	Period      string `json:"period" jsonschema:"description=Filter by period (optional)"`
 	Format      string `json:"format" jsonschema:"description=Output format: text, json, csv, markdown"`
 	ProjectPath string `json:"project_path,omitempty" jsonschema:"description=Path to the roady project directory (default: server root)"`
+	Project     string `json:"project,omitempty" jsonschema:"description=Sub-project name under .roady/projects/<name>/ (default: root project)"`
 }
 
 func (s *Server) handleCostReport(ctx context.Context, args CostReportArgs) (any, error) {
-	svc, err := s.servicesForPath(args.ProjectPath)
+	svc, err := s.servicesForPath(args.ProjectPath, args.Project)
 	if err != nil {
 		return nil, mcpErr("Failed to load project at the given path.")
 	}
@@ -1846,10 +1895,11 @@ func (s *Server) handleCostReport(ctx context.Context, args CostReportArgs) (any
 
 type CostBudgetArgs struct {
 	ProjectPath string `json:"project_path,omitempty" jsonschema:"description=Path to the roady project directory (default: server root)"`
+	Project     string `json:"project,omitempty" jsonschema:"description=Sub-project name under .roady/projects/<name>/ (default: root project)"`
 }
 
 func (s *Server) handleCostBudget(ctx context.Context, args CostBudgetArgs) (any, error) {
-	svc, err := s.servicesForPath(args.ProjectPath)
+	svc, err := s.servicesForPath(args.ProjectPath, args.Project)
 	if err != nil {
 		return nil, mcpErr("Failed to load project at the given path.")
 	}
@@ -1866,13 +1916,14 @@ func (s *Server) handleCostBudget(ctx context.Context, args CostBudgetArgs) (any
 type RateRemoveArgs struct {
 	ID          string `json:"id" jsonschema:"description=Rate ID to remove"`
 	ProjectPath string `json:"project_path,omitempty" jsonschema:"description=Path to the roady project directory (default: server root)"`
+	Project     string `json:"project,omitempty" jsonschema:"description=Sub-project name under .roady/projects/<name>/ (default: root project)"`
 }
 
 func (s *Server) handleRateRemove(ctx context.Context, args RateRemoveArgs) (string, error) {
 	if args.ID == "" {
 		return "", mcpErr("rate id is required")
 	}
-	svc, err := s.servicesForPath(args.ProjectPath)
+	svc, err := s.servicesForPath(args.ProjectPath, args.Project)
 	if err != nil {
 		return "", mcpErr("Failed to load project at the given path.")
 	}
@@ -1885,13 +1936,14 @@ func (s *Server) handleRateRemove(ctx context.Context, args RateRemoveArgs) (str
 type RateSetDefaultArgs struct {
 	ID          string `json:"id" jsonschema:"description=Rate ID to set as default"`
 	ProjectPath string `json:"project_path,omitempty" jsonschema:"description=Path to the roady project directory (default: server root)"`
+	Project     string `json:"project,omitempty" jsonschema:"description=Sub-project name under .roady/projects/<name>/ (default: root project)"`
 }
 
 func (s *Server) handleRateSetDefault(ctx context.Context, args RateSetDefaultArgs) (string, error) {
 	if args.ID == "" {
 		return "", mcpErr("rate id is required")
 	}
-	svc, err := s.servicesForPath(args.ProjectPath)
+	svc, err := s.servicesForPath(args.ProjectPath, args.Project)
 	if err != nil {
 		return "", mcpErr("Failed to load project at the given path.")
 	}
@@ -1906,6 +1958,7 @@ type RateTaxArgs struct {
 	Percent     float64 `json:"percent" jsonschema:"description=Tax percentage (e.g., 20 for 20%%)"`
 	Included    bool    `json:"included" jsonschema:"description=Tax is included in rate"`
 	ProjectPath string  `json:"project_path,omitempty" jsonschema:"description=Path to the roady project directory (default: server root)"`
+	Project     string `json:"project,omitempty" jsonschema:"description=Sub-project name under .roady/projects/<name>/ (default: root project)"`
 }
 
 func (s *Server) handleRateTax(ctx context.Context, args RateTaxArgs) (string, error) {
@@ -1915,7 +1968,7 @@ func (s *Server) handleRateTax(ctx context.Context, args RateTaxArgs) (string, e
 	if args.Percent < 0 || args.Percent > 100 {
 		return "", mcpErr("tax percent must be between 0 and 100")
 	}
-	svc, err := s.servicesForPath(args.ProjectPath)
+	svc, err := s.servicesForPath(args.ProjectPath, args.Project)
 	if err != nil {
 		return "", mcpErr("Failed to load project at the given path.")
 	}

--- a/internal/infrastructure/mcp/server.go
+++ b/internal/infrastructure/mcp/server.go
@@ -230,7 +230,7 @@ type InitArgs struct {
 type UpdatePlanArgs struct {
 	Tasks       []planning.Task `json:"tasks" jsonschema:"description=The list of tasks to define the plan"`
 	ProjectPath string          `json:"project_path,omitempty" jsonschema:"description=Path to the roady project directory (default: server root)"`
-	Project     string `json:"project,omitempty" jsonschema:"description=Sub-project name under .roady/projects/<name>/ (default: root project)"`
+	Project     string          `json:"project,omitempty" jsonschema:"description=Sub-project name under .roady/projects/<name>/ (default: root project)"`
 }
 
 // Args structs for handlers that previously used struct{}
@@ -1056,7 +1056,7 @@ type StatusArgs struct {
 	Limit       FlexInt  `json:"limit,omitempty" jsonschema:"description=Limit number of tasks returned"`
 	JSON        FlexBool `json:"json,omitempty" jsonschema:"description=Return structured JSON output instead of text"`
 	ProjectPath string   `json:"project_path,omitempty" jsonschema:"description=Path to the roady project directory (default: server root)"`
-	Project     string `json:"project,omitempty" jsonschema:"description=Sub-project name under .roady/projects/<name>/ (default: root project)"`
+	Project     string   `json:"project,omitempty" jsonschema:"description=Sub-project name under .roady/projects/<name>/ (default: root project)"`
 }
 
 func (s *Server) handleAssignTask(ctx context.Context, args AssignTaskArgs) (string, error) {
@@ -1819,7 +1819,7 @@ type RateAddArgs struct {
 	HourlyRate  float64 `json:"hourly_rate" jsonschema:"description=Hourly rate amount"`
 	IsDefault   bool    `json:"is_default" jsonschema:"description=Set as default rate"`
 	ProjectPath string  `json:"project_path,omitempty" jsonschema:"description=Path to the roady project directory (default: server root)"`
-	Project     string `json:"project,omitempty" jsonschema:"description=Sub-project name under .roady/projects/<name>/ (default: root project)"`
+	Project     string  `json:"project,omitempty" jsonschema:"description=Sub-project name under .roady/projects/<name>/ (default: root project)"`
 }
 
 func (s *Server) handleRateAdd(ctx context.Context, args RateAddArgs) (string, error) {
@@ -1958,7 +1958,7 @@ type RateTaxArgs struct {
 	Percent     float64 `json:"percent" jsonschema:"description=Tax percentage (e.g., 20 for 20%%)"`
 	Included    bool    `json:"included" jsonschema:"description=Tax is included in rate"`
 	ProjectPath string  `json:"project_path,omitempty" jsonschema:"description=Path to the roady project directory (default: server root)"`
-	Project     string `json:"project,omitempty" jsonschema:"description=Sub-project name under .roady/projects/<name>/ (default: root project)"`
+	Project     string  `json:"project,omitempty" jsonschema:"description=Sub-project name under .roady/projects/<name>/ (default: root project)"`
 }
 
 func (s *Server) handleRateTax(ctx context.Context, args RateTaxArgs) (string, error) {

--- a/internal/infrastructure/mcp/server_test.go
+++ b/internal/infrastructure/mcp/server_test.go
@@ -291,7 +291,7 @@ func TestServicesForPath_DefaultRoot(t *testing.T) {
 	}
 
 	// Empty override returns cached services
-	svc, err := server.servicesForPath("")
+	svc, err := server.servicesForPath("", "")
 	if err != nil {
 		t.Fatalf("servicesForPath empty: %v", err)
 	}
@@ -300,7 +300,7 @@ func TestServicesForPath_DefaultRoot(t *testing.T) {
 	}
 
 	// Same root returns cached services
-	svc, err = server.servicesForPath(root)
+	svc, err = server.servicesForPath(root, "")
 	if err != nil {
 		t.Fatalf("servicesForPath same root: %v", err)
 	}
@@ -340,7 +340,7 @@ func TestServicesForPath_Override(t *testing.T) {
 	}
 
 	// Override path builds fresh services
-	svc, err := server.servicesForPath(rootB)
+	svc, err := server.servicesForPath(rootB, "")
 	if err != nil {
 		t.Fatalf("servicesForPath override: %v", err)
 	}
@@ -386,11 +386,11 @@ func TestServicesForPath_CacheHitAndEviction(t *testing.T) {
 	}
 
 	// First call builds, second call should return the cached instance.
-	svc1, err := srv.servicesForPath(dirs[0])
+	svc1, err := srv.servicesForPath(dirs[0], "")
 	if err != nil {
 		t.Fatalf("first call: %v", err)
 	}
-	svc2, err := srv.servicesForPath(dirs[0])
+	svc2, err := srv.servicesForPath(dirs[0], "")
 	if err != nil {
 		t.Fatalf("cached call: %v", err)
 	}
@@ -400,13 +400,13 @@ func TestServicesForPath_CacheHitAndEviction(t *testing.T) {
 
 	// Fill the cache beyond the cap.
 	for _, d := range dirs[1:] {
-		if _, err := srv.servicesForPath(d); err != nil {
+		if _, err := srv.servicesForPath(d, ""); err != nil {
 			t.Fatalf("fill cache: %v", err)
 		}
 	}
 
 	// The first entry should have been evicted.
-	svc3, err := srv.servicesForPath(dirs[0])
+	svc3, err := srv.servicesForPath(dirs[0], "")
 	if err != nil {
 		t.Fatalf("post-eviction call: %v", err)
 	}

--- a/internal/infrastructure/wiring/services.go
+++ b/internal/infrastructure/wiring/services.go
@@ -3,7 +3,6 @@ package wiring
 import (
 	"context"
 	"fmt"
-	"path/filepath"
 
 	"github.com/felixgeelhaar/roady/pkg/application"
 	domainai "github.com/felixgeelhaar/roady/pkg/domain/ai"
@@ -39,28 +38,48 @@ type AppServices struct {
 // If the AI provider cannot be loaded (e.g. not configured), the server still starts —
 // only AI-dependent tools will return errors.
 func BuildAppServices(root string) (*AppServices, error) {
-	workspace := NewWorkspace(root)
+	return BuildAppServicesForProject(root, "")
+}
+
+// BuildAppServicesForProject constructs services scoped to a sub-project under
+// <root>/.roady/projects/<project>/. When project is empty, behaves like
+// BuildAppServices and uses the root project at <root>/.roady/.
+func BuildAppServicesForProject(root, project string) (*AppServices, error) {
+	workspace, err := NewWorkspaceForProject(root, project)
+	if err != nil {
+		return nil, err
+	}
 	provider, loadErr := LoadAIProvider(root)
 	// provider may be nil here — AI-dependent handlers must guard against this.
 
-	return buildServicesWithProvider(workspace, root, provider, loadErr)
+	return buildServicesWithProvider(workspace, provider, loadErr)
 }
 
 // BuildAppServicesWithProvider allows callers to supply a custom AI provider resolver.
+// Operates on the root project; sub-project callers should use BuildAppServicesWithProviderForProject.
 func BuildAppServicesWithProvider(root string, resolver func(string) (domainai.Provider, error)) (*AppServices, error) {
-	workspace := NewWorkspace(root)
+	return BuildAppServicesWithProviderForProject(root, "", resolver)
+}
+
+// BuildAppServicesWithProviderForProject is the sub-project-aware variant of BuildAppServicesWithProvider.
+func BuildAppServicesWithProviderForProject(root, project string, resolver func(string) (domainai.Provider, error)) (*AppServices, error) {
+	workspace, err := NewWorkspaceForProject(root, project)
+	if err != nil {
+		return nil, err
+	}
 	provider, err := resolver(root)
 	if err != nil {
 		return nil, fmt.Errorf("AI provider resolver failed: %w", err)
 	}
 
-	return buildServicesWithProvider(workspace, root, provider, nil)
+	return buildServicesWithProvider(workspace, provider, nil)
 }
 
 // buildServicesWithProvider is the shared implementation for building app services.
-func buildServicesWithProvider(workspace *Workspace, root string, provider domainai.Provider, loadErr error) (*AppServices, error) {
-	// Create event store and publisher for event-sourced audit
-	eventStore, err := storage.NewFileEventStore(filepath.Join(root, storage.RoadyDir))
+func buildServicesWithProvider(workspace *Workspace, provider domainai.Provider, loadErr error) (*AppServices, error) {
+	// Create event store and publisher for event-sourced audit.
+	// Events live next to the project's other files (so sub-projects have isolated event streams).
+	eventStore, err := storage.NewFileEventStore(workspace.Repo.ProjectBase())
 	if err != nil {
 		return nil, fmt.Errorf("create event store: %w", err)
 	}
@@ -116,8 +135,10 @@ func buildServicesWithProvider(workspace *Workspace, root string, provider domai
 
 	forecastSvc := application.NewForecastService(velocityProjection, workspace.Repo)
 
-	// Create dependency service
-	depSvc := application.NewDependencyService(workspace.Repo, root)
+	// Create dependency service. DependencyService resolves cross-repo deps via
+	// the workspace root (not the project base), so sub-projects share the same
+	// dependency search root as the repo they live in.
+	depSvc := application.NewDependencyService(workspace.Repo, workspace.Repo.Root())
 
 	services := &AppServices{
 		Workspace:  workspace,

--- a/internal/infrastructure/wiring/workspace.go
+++ b/internal/infrastructure/wiring/workspace.go
@@ -16,13 +16,27 @@ type Workspace struct {
 	Notifier *webhook.Notifier
 }
 
+// NewWorkspace constructs a workspace scoped to the root project at <root>/.roady/.
+// For a sub-project (<root>/.roady/projects/<name>/) use NewWorkspaceForProject.
 func NewWorkspace(root string) *Workspace {
-	repo := storage.NewFilesystemRepository(root)
+	ws, _ := NewWorkspaceForProject(root, "")
+	return ws
+}
 
-	// Load webhook config and create notifier if configured
+// NewWorkspaceForProject constructs a workspace scoped to a named sub-project
+// at <root>/.roady/projects/<project>/. When project is empty, behaves like
+// NewWorkspace. Returns an error if the project name is invalid.
+func NewWorkspaceForProject(root, project string) (*Workspace, error) {
+	repo, err := storage.NewFilesystemRepositoryForProject(root, project)
+	if err != nil {
+		return nil, err
+	}
+
+	// Load webhook config and create notifier if configured.
+	// Webhooks live next to the project's other files (under projects/<name>/ for sub-projects).
 	var notifier *webhook.Notifier
 	if config, err := repo.LoadWebhookConfig(); err == nil && len(config.Webhooks) > 0 {
-		dlPath := filepath.Join(root, storage.RoadyDir, storage.DeadLetterFile)
+		dlPath := filepath.Join(repo.ProjectBase(), storage.DeadLetterFile)
 		dlStore := webhook.NewDeadLetterStore(dlPath)
 		notifier = webhook.NewNotifier(config.Webhooks, dlStore)
 	}
@@ -32,5 +46,5 @@ func NewWorkspace(root string) *Workspace {
 		Audit:    application.NewAuditService(repo),
 		Usage:    application.NewUsageService(repo),
 		Notifier: notifier,
-	}
+	}, nil
 }

--- a/pkg/application/org_service.go
+++ b/pkg/application/org_service.go
@@ -122,12 +122,6 @@ func (s *OrgService) AggregateMetrics() (*org.OrgMetrics, error) {
 	return metrics, nil
 }
 
-// projectMetrics is the legacy single-arg form, kept for backward compatibility.
-// It scopes to the root project at <path>/.roady/.
-func (s *OrgService) projectMetrics(path string) org.ProjectMetrics {
-	return s.projectMetricsFor(DiscoveredProject{Path: path})
-}
-
 // projectMetricsFor reports metrics for a discovered project entry, supporting
 // both root projects and sub-projects under <Path>/.roady/projects/<SubProject>.
 func (s *OrgService) projectMetricsFor(p DiscoveredProject) org.ProjectMetrics {

--- a/pkg/application/org_service.go
+++ b/pkg/application/org_service.go
@@ -22,15 +22,61 @@ func NewOrgService(root string) *OrgService {
 	return &OrgService{root: root}
 }
 
-// DiscoverProjects walks the root directory tree and returns paths containing .roady directories.
+// DiscoveredProject identifies one project found during a walk.
+// SubProject is empty for the root project of a repo. For sub-projects
+// stored under <Path>/.roady/projects/<name>/, SubProject is set to <name>.
+type DiscoveredProject struct {
+	Path       string
+	SubProject string
+}
+
+// DiscoverProjects walks the root directory tree and returns paths containing
+// .roady directories. Backward-compatible shape — only root projects are
+// returned. For full sub-project discovery use DiscoverProjectsWithSub.
 func (s *OrgService) DiscoverProjects() ([]string, error) {
-	var projects []string
+	found, err := s.DiscoverProjectsWithSub()
+	if err != nil {
+		return nil, err
+	}
+	var paths []string
+	for _, p := range found {
+		if p.SubProject == "" {
+			paths = append(paths, p.Path)
+		}
+	}
+	return paths, nil
+}
+
+// DiscoverProjectsWithSub walks the root directory tree and returns every
+// project found — both the root project of each repo (where a .roady/ lives)
+// and every named sub-project under <repo>/.roady/projects/<name>/.
+func (s *OrgService) DiscoverProjectsWithSub() ([]DiscoveredProject, error) {
+	var projects []DiscoveredProject
 	err := filepath.Walk(s.root, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return nil
 		}
 		if info.IsDir() && info.Name() == ".roady" {
-			projects = append(projects, filepath.Dir(path))
+			repoRoot := filepath.Dir(path)
+			projects = append(projects, DiscoveredProject{Path: repoRoot})
+
+			// Look for sub-projects under .roady/projects/<name>/
+			projectsDir := filepath.Join(path, storage.ProjectsDir)
+			if entries, err := os.ReadDir(projectsDir); err == nil {
+				for _, entry := range entries {
+					if !entry.IsDir() {
+						continue
+					}
+					name := entry.Name()
+					if err := storage.ValidateProjectName(name); err != nil {
+						continue
+					}
+					projects = append(projects, DiscoveredProject{
+						Path:       repoRoot,
+						SubProject: name,
+					})
+				}
+			}
 			return filepath.SkipDir
 		}
 		return nil
@@ -38,9 +84,10 @@ func (s *OrgService) DiscoverProjects() ([]string, error) {
 	return projects, err
 }
 
-// AggregateMetrics collects metrics from all discovered projects.
+// AggregateMetrics collects metrics from all discovered projects, including
+// sub-projects under each repo's .roady/projects/<name>/.
 func (s *OrgService) AggregateMetrics() (*org.OrgMetrics, error) {
-	projects, err := s.DiscoverProjects()
+	projects, err := s.DiscoverProjectsWithSub()
 	if err != nil {
 		return nil, err
 	}
@@ -56,7 +103,7 @@ func (s *OrgService) AggregateMetrics() (*org.OrgMetrics, error) {
 	}
 
 	for _, p := range projects {
-		pm := s.projectMetrics(p)
+		pm := s.projectMetricsFor(p)
 		metrics.Projects = append(metrics.Projects, pm)
 		metrics.TotalTasks += pm.Total
 		metrics.TotalVerified += pm.Verified
@@ -75,23 +122,47 @@ func (s *OrgService) AggregateMetrics() (*org.OrgMetrics, error) {
 	return metrics, nil
 }
 
+// projectMetrics is the legacy single-arg form, kept for backward compatibility.
+// It scopes to the root project at <path>/.roady/.
 func (s *OrgService) projectMetrics(path string) org.ProjectMetrics {
-	repo := storage.NewFilesystemRepository(path)
+	return s.projectMetricsFor(DiscoveredProject{Path: path})
+}
+
+// projectMetricsFor reports metrics for a discovered project entry, supporting
+// both root projects and sub-projects under <Path>/.roady/projects/<SubProject>.
+func (s *OrgService) projectMetricsFor(p DiscoveredProject) org.ProjectMetrics {
+	repo, repoErr := storage.NewFilesystemRepositoryForProject(p.Path, p.SubProject)
+	if repoErr != nil {
+		// Invalid sub-project name; fall back to legacy root repo so we don't
+		// silently drop the entry.
+		repo = storage.NewFilesystemRepository(p.Path)
+	}
 	spec, _ := repo.LoadSpec()
 	plan, _ := repo.LoadPlan()
 	state, _ := repo.LoadState()
 
+	displayName := filepath.Base(p.Path)
+	if p.SubProject != "" {
+		displayName = filepath.Base(p.Path) + "/" + p.SubProject
+	}
 	pm := org.ProjectMetrics{
-		Name: filepath.Base(path),
-		Path: path,
+		Name: displayName,
+		Path: p.Path,
+	}
+	if p.SubProject != "" {
+		// Surface the sub-project path so callers see the actual on-disk location.
+		pm.Path = repo.ProjectBase()
 	}
 
-	if absPath, err := filepath.Abs(path); err == nil {
+	if absPath, err := filepath.Abs(pm.Path); err == nil {
 		pm.Path = absPath
 	}
 
 	if spec != nil {
 		pm.Name = spec.Title
+		if p.SubProject != "" && spec.Title != "" {
+			pm.Name = spec.Title + " (" + p.SubProject + ")"
+		}
 	}
 
 	if plan != nil {
@@ -193,9 +264,10 @@ func (s *OrgService) LoadMergedPolicy(projectPath string) (*policy.PolicyConfig,
 	return merged, nil
 }
 
-// DetectCrossDrift discovers projects and aggregates drift reports.
+// DetectCrossDrift discovers projects (including sub-projects) and aggregates
+// drift reports.
 func (s *OrgService) DetectCrossDrift() (*org.CrossDriftReport, error) {
-	projects, err := s.DiscoverProjects()
+	projects, err := s.DiscoverProjectsWithSub()
 	if err != nil {
 		return nil, err
 	}
@@ -203,25 +275,39 @@ func (s *OrgService) DetectCrossDrift() (*org.CrossDriftReport, error) {
 	report := &org.CrossDriftReport{}
 
 	for _, p := range projects {
-		repo := storage.NewFilesystemRepository(p)
+		repo, repoErr := storage.NewFilesystemRepositoryForProject(p.Path, p.SubProject)
+		if repoErr != nil {
+			continue
+		}
 		auditSvc := NewAuditService(repo)
 		policySvc := NewPolicyService(repo)
 		inspector := storage.NewCodebaseInspector()
 		driftSvc := NewDriftService(repo, auditSvc, inspector, policySvc)
 
 		driftReport, err := driftSvc.DetectDrift(context.Background())
+		displayPath := p.Path
+		if p.SubProject != "" {
+			displayPath = repo.ProjectBase()
+		}
+		displayName := filepath.Base(p.Path)
+		if p.SubProject != "" {
+			displayName = filepath.Base(p.Path) + "/" + p.SubProject
+		}
 		summary := org.ProjectDriftSummary{
-			Name: filepath.Base(p),
-			Path: p,
+			Name: displayName,
+			Path: displayPath,
 		}
 
-		if absPath, absErr := filepath.Abs(p); absErr == nil {
+		if absPath, absErr := filepath.Abs(displayPath); absErr == nil {
 			summary.Path = absPath
 		}
 
 		// Try to get project name from spec
 		if spec, specErr := repo.LoadSpec(); specErr == nil && spec != nil {
 			summary.Name = spec.Title
+			if p.SubProject != "" && spec.Title != "" {
+				summary.Name = spec.Title + " (" + p.SubProject + ")"
+			}
 		}
 
 		if err == nil && driftReport != nil && len(driftReport.Issues) > 0 {

--- a/pkg/storage/filesystem.go
+++ b/pkg/storage/filesystem.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -18,6 +19,7 @@ import (
 )
 
 const RoadyDir = ".roady"
+const ProjectsDir = "projects"
 const SpecFile = "spec.yaml"
 const SpecLockFile = "spec.lock.json"
 const PlanFile = "plan.json"
@@ -30,11 +32,40 @@ const DeadLetterFile = "deadletters.jsonl"
 const RatesFile = "rates.yaml"
 const TimeEntriesFile = "time_entries.yaml"
 
+// projectNamePattern restricts sub-project names to a safe, lowercase, slug-like form.
+// Names must start with [a-z0-9] and may contain [a-z0-9._-]. Max 64 chars.
+// The literal "projects" is reserved because it is the parent directory name.
+var projectNamePattern = regexp.MustCompile(`^[a-z0-9][a-z0-9._-]{0,63}$`)
+
+// ValidateProjectName returns nil if name is a valid sub-project identifier.
+// Empty name is valid and refers to the root project.
+func ValidateProjectName(name string) error {
+	if name == "" {
+		return nil
+	}
+	if name == "." || name == ".." {
+		return fmt.Errorf("invalid project name: %q", name)
+	}
+	if name == ProjectsDir {
+		return fmt.Errorf("project name %q is reserved", name)
+	}
+	if strings.ContainsAny(name, "/\\") {
+		return fmt.Errorf("project name must not contain path separators: %q", name)
+	}
+	if !projectNamePattern.MatchString(name) {
+		return fmt.Errorf("project name must match %s: %q", projectNamePattern, name)
+	}
+	return nil
+}
+
 type FilesystemRepository struct {
 	root        string
+	subProject  string // empty = root project; otherwise stored under .roady/projects/<name>/
 	retryConfig retry.Config
 }
 
+// NewFilesystemRepository returns a repository scoped to the root project
+// (<root>/.roady/). Equivalent to NewFilesystemRepositoryForProject(root, "").
 func NewFilesystemRepository(root string) *FilesystemRepository {
 	return &FilesystemRepository{
 		root: root,
@@ -46,23 +77,60 @@ func NewFilesystemRepository(root string) *FilesystemRepository {
 	}
 }
 
+// NewFilesystemRepositoryForProject returns a repository scoped to a named
+// sub-project at <root>/.roady/projects/<project>/. When project is empty,
+// behaves like NewFilesystemRepository. Returns an error if the project name
+// is invalid.
+func NewFilesystemRepositoryForProject(root, project string) (*FilesystemRepository, error) {
+	if err := ValidateProjectName(project); err != nil {
+		return nil, err
+	}
+	r := NewFilesystemRepository(root)
+	r.subProject = project
+	return r, nil
+}
+
 // Root returns the workspace root directory.
 func (r *FilesystemRepository) Root() string {
 	return r.root
 }
 
-// ResolvePath ensures the path is within the .roady directory and prevents traversal.
+// SubProject returns the sub-project name this repository is scoped to,
+// or "" if it is scoped to the root project.
+func (r *FilesystemRepository) SubProject() string {
+	return r.subProject
+}
+
+// IsSubProject reports whether this repository is scoped to a named
+// sub-project rather than the root project.
+func (r *FilesystemRepository) IsSubProject() bool {
+	return r.subProject != ""
+}
+
+// ProjectBase returns the directory that contains this project's files.
+// For the root project that is <root>/.roady. For a sub-project it is
+// <root>/.roady/projects/<name>.
+func (r *FilesystemRepository) ProjectBase() string {
+	base := filepath.Join(r.root, RoadyDir)
+	if r.subProject == "" {
+		return base
+	}
+	return filepath.Join(base, ProjectsDir, r.subProject)
+}
+
+// ResolvePath ensures the path is within this project's directory and prevents
+// traversal. For root projects the base is <root>/.roady; for sub-projects it
+// is <root>/.roady/projects/<name>. Only direct children are allowed.
 func (r *FilesystemRepository) ResolvePath(filename string) (string, error) {
 	if filename == "" {
 		return "", fmt.Errorf("filename cannot be empty")
 	}
 
-	// Base directory is strictly root/.roady
-	baseDir := filepath.Join(r.root, RoadyDir)
+	baseDir := r.ProjectBase()
 	fullPath := filepath.Join(baseDir, filename)
 	cleanPath := filepath.Clean(fullPath)
 
-	// Check for traversal and ensure it's a direct child (no nested subdirs in .roady for now)
+	// Ensure the resolved path is a direct child of baseDir.
 	if !strings.HasPrefix(cleanPath, baseDir) || filepath.Dir(cleanPath) != baseDir {
 		return "", fmt.Errorf("invalid file path: %s", filename)
 	}
@@ -71,16 +139,16 @@ func (r *FilesystemRepository) ResolvePath(filename string) (string, error) {
 }
 
 func (r *FilesystemRepository) Initialize() error {
-	path := filepath.Join(r.root, RoadyDir)
+	path := r.ProjectBase()
 	// G301: Use 0700 for directories
 	if err := os.MkdirAll(path, 0700); err != nil {
-		return fmt.Errorf("failed to create .roady directory: %w", err)
+		return fmt.Errorf("failed to create project directory: %w", err)
 	}
 	return nil
 }
 
 func (r *FilesystemRepository) IsInitialized() bool {
-	_, err := os.Stat(filepath.Join(r.root, RoadyDir))
+	_, err := os.Stat(r.ProjectBase())
 	return err == nil
 }
 

--- a/pkg/storage/filesystem_subproject_test.go
+++ b/pkg/storage/filesystem_subproject_test.go
@@ -1,0 +1,192 @@
+package storage
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/felixgeelhaar/roady/pkg/domain/spec"
+)
+
+func TestValidateProjectName(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{"empty is root project", "", false},
+		{"simple", "auth", false},
+		{"with dash", "feature-auth", false},
+		{"with underscore", "feature_auth", false},
+		{"with dot", "v1.2", false},
+		{"alphanum", "abc123", false},
+
+		{"dot reserved", ".", true},
+		{"dotdot reserved", "..", true},
+		{"projects literal reserved", "projects", true},
+		{"path separator", "foo/bar", true},
+		{"backslash separator", "foo\\bar", true},
+		{"uppercase rejected", "Auth", true},
+		{"leading dash rejected", "-auth", true},
+		{"leading dot rejected", ".auth", true},
+		{"too long", strings.Repeat("a", 65), true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateProjectName(tc.input)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("ValidateProjectName(%q) err=%v, wantErr=%v", tc.input, err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestNewFilesystemRepositoryForProject_Invalid(t *testing.T) {
+	_, err := NewFilesystemRepositoryForProject("/tmp", "Bad/Name")
+	if err == nil {
+		t.Fatal("expected error for invalid project name")
+	}
+}
+
+func TestFilesystemRepository_SubProjectPaths(t *testing.T) {
+	root := t.TempDir()
+
+	rootRepo := NewFilesystemRepository(root)
+	if rootRepo.IsSubProject() {
+		t.Error("root-project repo reports IsSubProject true")
+	}
+	if got := rootRepo.SubProject(); got != "" {
+		t.Errorf("root SubProject = %q, want empty", got)
+	}
+	if got := rootRepo.ProjectBase(); got != filepath.Join(root, RoadyDir) {
+		t.Errorf("root ProjectBase = %q, want %q", got, filepath.Join(root, RoadyDir))
+	}
+
+	subRepo, err := NewFilesystemRepositoryForProject(root, "feature-auth")
+	if err != nil {
+		t.Fatalf("NewFilesystemRepositoryForProject: %v", err)
+	}
+	if !subRepo.IsSubProject() {
+		t.Error("sub-project repo reports IsSubProject false")
+	}
+	if got := subRepo.SubProject(); got != "feature-auth" {
+		t.Errorf("sub SubProject = %q, want feature-auth", got)
+	}
+	wantBase := filepath.Join(root, RoadyDir, ProjectsDir, "feature-auth")
+	if got := subRepo.ProjectBase(); got != wantBase {
+		t.Errorf("sub ProjectBase = %q, want %q", got, wantBase)
+	}
+
+	resolved, err := subRepo.ResolvePath(SpecFile)
+	if err != nil {
+		t.Fatalf("ResolvePath: %v", err)
+	}
+	want := filepath.Join(wantBase, SpecFile)
+	if resolved != want {
+		t.Errorf("ResolvePath = %q, want %q", resolved, want)
+	}
+
+	// Traversal must still be rejected on sub-project repos.
+	if _, err := subRepo.ResolvePath("../" + SpecFile); err == nil {
+		t.Error("expected error for traversal out of sub-project")
+	}
+	if _, err := subRepo.ResolvePath("sub/nested.yaml"); err == nil {
+		t.Error("expected error for nested filename under sub-project")
+	}
+}
+
+func TestFilesystemRepository_SubProject_InitializeAndIsInitialized(t *testing.T) {
+	root := t.TempDir()
+	subRepo, err := NewFilesystemRepositoryForProject(root, "billing")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if subRepo.IsInitialized() {
+		t.Fatal("expected IsInitialized=false before Initialize")
+	}
+	if err := subRepo.Initialize(); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	if !subRepo.IsInitialized() {
+		t.Fatal("expected IsInitialized=true after Initialize")
+	}
+
+	wantPath := filepath.Join(root, RoadyDir, ProjectsDir, "billing")
+	if fi, err := os.Stat(wantPath); err != nil || !fi.IsDir() {
+		t.Fatalf("expected sub-project dir at %q, err=%v", wantPath, err)
+	}
+}
+
+func TestFilesystemRepository_SubProject_Isolation(t *testing.T) {
+	root := t.TempDir()
+
+	// Set up: root project + two sub-projects, all with distinct specs.
+	rootRepo := NewFilesystemRepository(root)
+	if err := rootRepo.Initialize(); err != nil {
+		t.Fatal(err)
+	}
+	authRepo, err := NewFilesystemRepositoryForProject(root, "auth")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := authRepo.Initialize(); err != nil {
+		t.Fatal(err)
+	}
+	billingRepo, err := NewFilesystemRepositoryForProject(root, "billing")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := billingRepo.Initialize(); err != nil {
+		t.Fatal(err)
+	}
+
+	rootSpec := &spec.ProductSpec{ID: "root-spec"}
+	authSpec := &spec.ProductSpec{ID: "auth-spec"}
+	billingSpec := &spec.ProductSpec{ID: "billing-spec"}
+
+	if err := rootRepo.SaveSpec(rootSpec); err != nil {
+		t.Fatal(err)
+	}
+	if err := authRepo.SaveSpec(authSpec); err != nil {
+		t.Fatal(err)
+	}
+	if err := billingRepo.SaveSpec(billingSpec); err != nil {
+		t.Fatal(err)
+	}
+
+	got1, err := rootRepo.LoadSpec()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got1.ID != "root-spec" {
+		t.Errorf("rootRepo LoadSpec ID = %q, want root-spec", got1.ID)
+	}
+	got2, err := authRepo.LoadSpec()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got2.ID != "auth-spec" {
+		t.Errorf("authRepo LoadSpec ID = %q, want auth-spec", got2.ID)
+	}
+	got3, err := billingRepo.LoadSpec()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got3.ID != "billing-spec" {
+		t.Errorf("billingRepo LoadSpec ID = %q, want billing-spec", got3.ID)
+	}
+
+	// Verify the files actually live where expected on disk.
+	for _, want := range []string{
+		filepath.Join(root, RoadyDir, SpecFile),
+		filepath.Join(root, RoadyDir, ProjectsDir, "auth", SpecFile),
+		filepath.Join(root, RoadyDir, ProjectsDir, "billing", SpecFile),
+	} {
+		if _, err := os.Stat(want); err != nil {
+			t.Errorf("expected spec file at %q: %v", want, err)
+		}
+	}
+}

--- a/pkg/storage/filesystem_test.go
+++ b/pkg/storage/filesystem_test.go
@@ -109,10 +109,12 @@ func TestFilesystemRepository_Thorough(t *testing.T) {
 		t.Error("Expected error for traversal")
 	}
 
-	// 8.1 ResolvePath Nested (blocked)
+	// 8.1 ResolvePath rejects arbitrary nested paths on a root-project repo.
+	// Sub-project files are addressed by constructing a sub-project repository
+	// (NewFilesystemRepositoryForProject), not by passing a nested filename here.
 	_, err = repo.ResolvePath("sub/file.yaml")
 	if err == nil {
-		t.Error("expected error for nested path")
+		t.Error("expected error for nested path on root-project repo")
 	}
 
 	validPath, _ := repo.ResolvePath("spec.yaml")


### PR DESCRIPTION
## Summary

Allow a single repository to host multiple Roady projects side-by-side under one `.roady/` directory by placing each named sub-project at `.roady/projects/<name>/`. Existing flat repositories continue to work unchanged — their `.roady/` contents form an implicit \"root project\".

One coding agent can now manage many feature- or product-scoped projects in the same workspace by switching \`--project <name>\` (CLI) or \`project\` (MCP) without changing directories.

## Surface changes

- **CLI:** new global flag \`--project / -P <name>\` (env: \`ROADY_PROJECT\`). No flag = root project.
- **MCP:** new optional \`project\` field on every tool that already takes \`project_path\`. \`AppServices\` cached per (path, project) key.
- **Storage:** new \`NewFilesystemRepositoryForProject(root, name)\` + helpers \`ProjectBase()\`, \`SubProject()\`, \`IsSubProject()\`. Legacy \`NewFilesystemRepository(root)\` unchanged.
- **Org:** new \`OrgService.DiscoverProjectsWithSub()\` returns root + sub-projects. \`DiscoverProjects()\` (legacy) returns root only — unchanged shape.
- **Discovery:** \`roady discover\` and \`roady org status\` surface sub-projects.

## Layout

\`\`\`
repo/
  .roady/                            # root project (unchanged)
    spec.yaml, plan.json, state.json, events.jsonl, policy.yaml, ...
    projects/                        # NEW
      feature-auth/{spec.yaml, plan.json, state.json, ...}
      feature-payments/{spec.yaml, plan.json, ...}
\`\`\`

Sub-project name regex: \`^[a-z0-9][a-z0-9._-]{0,63}\$\`. \`projects\` is reserved.

## Backward compatibility

| Surface | Compatibility |
|---|---|
| Existing flat \`.roady/\` repos | Unchanged |
| All existing public constructors / methods | Signatures unchanged |
| MCP request structs | \`project_path\` unchanged; \`project\` is new + optional |
| \`roady discover\` / \`roady org status\` output | Adds sub-project lines |

No deprecations, no data migration.

## Test plan

- [x] Full \`go test ./...\` green (38 packages, 0 FAILs)
- [x] New unit tests in \`pkg/storage/filesystem_subproject_test.go\` (name validation, path scoping, isolation, traversal rejection, init + IsInitialized)
- [x] E2E: \`init\` + \`-P auth init\` + \`-P billing init\` creates correct nested layout; files isolated per project
- [x] E2E: \`roady discover\` surfaces 1 root + 2 sub-projects
- [x] E2E: \`roady org status\` shows 3 rows with sub-project names

See \`docs/rfcs/0001-nested-projects.md\` for full design.

## Out of scope

- Cross-project task dependencies (\`@project:task-id\` syntax) — deferred to follow-up RFC
- Single org-level Kanban dashboard collating sub-projects — deferred
- CLI to rename / move sub-projects — today: edit directory name on disk