### PR TITLE
feat(dashboard): Kanban view at /kanban

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — Kanban dashboard view
+
+- New `/kanban` route on the web dashboard (`roady dashboard serve`) renders the project's tasks across five status columns: **Backlog · Ready · In Progress · Blocked · Done**. Auto-refreshes every 30s.
+- "Ready" computes dependency satisfaction so unblocked pending tasks surface separately from backlog items waiting on upstream work. "Done" rolls Verified into Done.
+- New JSON endpoint `/api/kanban` returns the same board for external tools / IDE plugins / CI.
+- Nav bar across dashboard pages gains a Kanban link.
+
 ### Added — Nested sub-projects
 
 - A single repository can now host multiple Roady projects side-by-side under one `.roady/` directory by placing each named sub-project at `.roady/projects/<name>/`. See `docs/rfcs/0001-nested-projects.md`.

--- a/pkg/infrastructure/dashboard/kanban.go
+++ b/pkg/infrastructure/dashboard/kanban.go
@@ -1,0 +1,168 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"net/http"
+	"sort"
+	"time"
+
+	"github.com/felixgeelhaar/roady/pkg/domain/planning"
+)
+
+// KanbanBoard groups the plan's tasks into status columns for a Kanban view.
+type KanbanBoard struct {
+	Columns     []KanbanColumn `json:"columns"`
+	ProjectName string         `json:"project_name,omitempty"`
+	TotalTasks  int            `json:"total_tasks"`
+	UpdatedAt   time.Time      `json:"updated_at"`
+}
+
+// KanbanColumn is one status lane on the board.
+type KanbanColumn struct {
+	Name   string     `json:"name"`
+	Status string     `json:"status"` // matches statusClass()
+	Tasks  []TaskView `json:"tasks"`
+	Count  int        `json:"count"`
+}
+
+// kanbanColumnOrder defines the column order rendered on the board.
+// Backlog → tasks with no state or status=pending AND with unmet dependencies.
+// Ready   → pending tasks whose dependencies are all done/verified.
+// Other columns map directly to TaskStatus values.
+var kanbanColumnOrder = []struct {
+	Name   string
+	Status string
+}{
+	{"Backlog", "backlog"},
+	{"Ready", "ready"},
+	{"In Progress", string(planning.StatusInProgress)},
+	{"Blocked", string(planning.StatusBlocked)},
+	{"Done", string(planning.StatusDone)},
+}
+
+// buildKanbanBoard returns a board grouped by column, ordered by kanbanColumnOrder.
+// Within each column tasks are sorted by ID for stable rendering.
+func buildKanbanBoard(plan *planning.Plan, state *planning.ExecutionState) KanbanBoard {
+	board := KanbanBoard{
+		UpdatedAt: time.Now(),
+	}
+	if plan == nil {
+		for _, c := range kanbanColumnOrder {
+			board.Columns = append(board.Columns, KanbanColumn{Name: c.Name, Status: c.Status})
+		}
+		return board
+	}
+
+	// Index task status to compute readiness.
+	taskStatus := map[string]planning.TaskStatus{}
+	for _, t := range plan.Tasks {
+		taskStatus[t.ID] = planning.StatusPending
+	}
+	if state != nil {
+		for id, r := range state.TaskStates {
+			taskStatus[id] = r.Status
+		}
+	}
+
+	cols := map[string]*KanbanColumn{}
+	for _, c := range kanbanColumnOrder {
+		cols[c.Status] = &KanbanColumn{Name: c.Name, Status: c.Status}
+	}
+
+	for _, task := range plan.Tasks {
+		view := TaskView{Task: task, Status: planning.StatusPending}
+		if state != nil {
+			if r, ok := state.TaskStates[task.ID]; ok {
+				view.Status = r.Status
+				view.Owner = r.Owner
+				view.HasLinks = len(r.ExternalRefs) > 0
+			}
+		}
+
+		var target string
+		switch view.Status {
+		case planning.StatusInProgress:
+			target = string(planning.StatusInProgress)
+		case planning.StatusBlocked:
+			target = string(planning.StatusBlocked)
+		case planning.StatusDone, planning.StatusVerified:
+			target = string(planning.StatusDone)
+		default:
+			if dependenciesMet(task, taskStatus) {
+				target = "ready"
+			} else {
+				target = "backlog"
+			}
+		}
+
+		col := cols[target]
+		if col == nil {
+			// Defensive: unknown status falls into backlog.
+			col = cols["backlog"]
+		}
+		col.Tasks = append(col.Tasks, view)
+	}
+
+	for _, c := range kanbanColumnOrder {
+		col := cols[c.Status]
+		sort.SliceStable(col.Tasks, func(i, j int) bool {
+			return col.Tasks[i].Task.ID < col.Tasks[j].Task.ID
+		})
+		col.Count = len(col.Tasks)
+		board.Columns = append(board.Columns, *col)
+		board.TotalTasks += col.Count
+	}
+	return board
+}
+
+// dependenciesMet returns true when every task in DependsOn has reached a
+// terminal positive state (done or verified). Unknown dependency IDs are
+// treated as not met so the task stays in backlog.
+func dependenciesMet(task planning.Task, byID map[string]planning.TaskStatus) bool {
+	for _, dep := range task.DependsOn {
+		s, ok := byID[dep]
+		if !ok {
+			return false
+		}
+		if s != planning.StatusDone && s != planning.StatusVerified {
+			return false
+		}
+	}
+	return true
+}
+
+// kanbanData wraps the board plus standard PageData so templates can share
+// the layout with other dashboard pages.
+type kanbanData struct {
+	Title string
+	Board KanbanBoard
+	Error string
+}
+
+func (s *Server) handleKanban(w http.ResponseWriter, r *http.Request) {
+	data := kanbanData{Title: "Kanban"}
+
+	plan, err := s.provider.GetPlan()
+	if err != nil {
+		data.Error = err.Error()
+		s.render(w, "kanban.html", data)
+		return
+	}
+	state, _ := s.provider.GetState()
+	data.Board = buildKanbanBoard(plan, state)
+
+	s.render(w, "kanban.html", data)
+}
+
+func (s *Server) handleAPIKanban(w http.ResponseWriter, r *http.Request) {
+	plan, err := s.provider.GetPlan()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	state, _ := s.provider.GetState()
+	board := buildKanbanBoard(plan, state)
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(board)
+}

--- a/pkg/infrastructure/dashboard/kanban_test.go
+++ b/pkg/infrastructure/dashboard/kanban_test.go
@@ -1,0 +1,190 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/felixgeelhaar/roady/pkg/domain/planning"
+)
+
+type kanbanStubProvider struct {
+	plan  *planning.Plan
+	state *planning.ExecutionState
+	err   error
+}
+
+func (s *kanbanStubProvider) GetPlan() (*planning.Plan, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.plan, nil
+}
+
+func (s *kanbanStubProvider) GetState() (*planning.ExecutionState, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.state, nil
+}
+
+func sampleKanbanPlan() *planning.Plan {
+	return &planning.Plan{
+		ID: "plan-1",
+		Tasks: []planning.Task{
+			{ID: "a-ready", Title: "ready"},
+			{ID: "b-progress", Title: "in progress"},
+			{ID: "c-blocked", Title: "blocked"},
+			{ID: "d-done", Title: "done"},
+			{ID: "e-backlog", Title: "backlog (unmet dep)", DependsOn: []string{"f-missing"}},
+			{ID: "g-ready-dep", Title: "ready (dep done)", DependsOn: []string{"d-done"}},
+		},
+	}
+}
+
+func sampleKanbanState() *planning.ExecutionState {
+	return &planning.ExecutionState{
+		TaskStates: map[string]planning.TaskResult{
+			"b-progress": {Status: planning.StatusInProgress, Owner: "alice"},
+			"c-blocked":  {Status: planning.StatusBlocked},
+			"d-done":     {Status: planning.StatusDone},
+		},
+	}
+}
+
+func TestBuildKanbanBoard_ColumnOrderAndCounts(t *testing.T) {
+	board := buildKanbanBoard(sampleKanbanPlan(), sampleKanbanState())
+
+	if got, want := len(board.Columns), 5; got != want {
+		t.Fatalf("columns = %d, want %d", got, want)
+	}
+	wantOrder := []string{"backlog", "ready", string(planning.StatusInProgress), string(planning.StatusBlocked), string(planning.StatusDone)}
+	for i, want := range wantOrder {
+		if board.Columns[i].Status != want {
+			t.Errorf("column[%d].Status = %q, want %q", i, board.Columns[i].Status, want)
+		}
+	}
+
+	wantCount := map[string]int{
+		"backlog":                         1,
+		"ready":                           2, // a-ready + g-ready-dep (dep d-done is done)
+		string(planning.StatusInProgress): 1,
+		string(planning.StatusBlocked):    1,
+		string(planning.StatusDone):       1,
+	}
+	for _, c := range board.Columns {
+		if got, want := c.Count, wantCount[c.Status]; got != want {
+			t.Errorf("column %q count = %d, want %d", c.Status, got, want)
+		}
+	}
+	if board.TotalTasks != len(sampleKanbanPlan().Tasks) {
+		t.Errorf("TotalTasks = %d, want %d", board.TotalTasks, len(sampleKanbanPlan().Tasks))
+	}
+}
+
+func TestBuildKanbanBoard_VerifiedRollsIntoDone(t *testing.T) {
+	plan := &planning.Plan{Tasks: []planning.Task{{ID: "x", Title: "verified"}}}
+	state := &planning.ExecutionState{TaskStates: map[string]planning.TaskResult{
+		"x": {Status: planning.StatusVerified},
+	}}
+	board := buildKanbanBoard(plan, state)
+	for _, c := range board.Columns {
+		if c.Status == string(planning.StatusDone) {
+			if c.Count != 1 {
+				t.Errorf("done column count = %d, want 1", c.Count)
+			}
+			return
+		}
+	}
+	t.Fatal("done column not found")
+}
+
+func TestBuildKanbanBoard_EmptyPlan(t *testing.T) {
+	board := buildKanbanBoard(nil, nil)
+	if len(board.Columns) != 5 {
+		t.Fatalf("expected 5 empty columns, got %d", len(board.Columns))
+	}
+	for _, c := range board.Columns {
+		if c.Count != 0 {
+			t.Errorf("empty plan column %q count = %d, want 0", c.Status, c.Count)
+		}
+	}
+}
+
+func TestBuildKanbanBoard_StableTaskOrder(t *testing.T) {
+	plan := &planning.Plan{Tasks: []planning.Task{
+		{ID: "z", Title: "z"},
+		{ID: "a", Title: "a"},
+		{ID: "m", Title: "m"},
+	}}
+	board := buildKanbanBoard(plan, nil)
+	var ready *KanbanColumn
+	for i := range board.Columns {
+		if board.Columns[i].Status == "ready" {
+			ready = &board.Columns[i]
+			break
+		}
+	}
+	if ready == nil || ready.Count != 3 {
+		t.Fatalf("ready column missing or wrong count: %+v", ready)
+	}
+	wantOrder := []string{"a", "m", "z"}
+	for i, tv := range ready.Tasks {
+		if tv.Task.ID != wantOrder[i] {
+			t.Errorf("ready[%d] = %q, want %q", i, tv.Task.ID, wantOrder[i])
+		}
+	}
+}
+
+func TestKanbanHTMLHandler_RendersAllColumns(t *testing.T) {
+	srv, err := NewServer(":0", &kanbanStubProvider{plan: sampleKanbanPlan(), state: sampleKanbanState()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequest(http.MethodGet, "/kanban", nil)
+	rec := httptest.NewRecorder()
+	srv.handleKanban(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	body := rec.Body.String()
+	for _, want := range []string{"Backlog", "Ready", "In Progress", "Blocked", "Done", "auto-refresh 30s"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("body missing %q", want)
+		}
+	}
+	if !strings.Contains(body, "col-in_progress") {
+		t.Error("expected col-in_progress class in body")
+	}
+}
+
+func TestKanbanAPIHandler_ReturnsJSON(t *testing.T) {
+	srv, err := NewServer(":0", &kanbanStubProvider{plan: sampleKanbanPlan(), state: sampleKanbanState()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequest(http.MethodGet, "/api/kanban", nil)
+	rec := httptest.NewRecorder()
+	srv.handleAPIKanban(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if got := rec.Header().Get("Content-Type"); got != "application/json" {
+		t.Errorf("content-type = %q, want application/json", got)
+	}
+	var board KanbanBoard
+	if err := json.Unmarshal(rec.Body.Bytes(), &board); err != nil {
+		t.Fatalf("json decode: %v", err)
+	}
+	if len(board.Columns) != 5 {
+		t.Errorf("columns = %d, want 5", len(board.Columns))
+	}
+	if board.UpdatedAt.IsZero() || time.Since(board.UpdatedAt) > time.Second {
+		t.Errorf("UpdatedAt looks stale: %v", board.UpdatedAt)
+	}
+}

--- a/pkg/infrastructure/dashboard/server.go
+++ b/pkg/infrastructure/dashboard/server.go
@@ -58,8 +58,10 @@ func (s *Server) Start() error {
 	mux.HandleFunc("GET /", s.handleIndex)
 	mux.HandleFunc("GET /plan", s.handlePlan)
 	mux.HandleFunc("GET /tasks", s.handleTasks)
+	mux.HandleFunc("GET /kanban", s.handleKanban)
 	mux.HandleFunc("GET /api/plan", s.handleAPIPlan)
 	mux.HandleFunc("GET /api/state", s.handleAPIState)
+	mux.HandleFunc("GET /api/kanban", s.handleAPIKanban)
 
 	s.server = &http.Server{
 		Addr:         s.addr,

--- a/pkg/infrastructure/dashboard/templates/index.html
+++ b/pkg/infrastructure/dashboard/templates/index.html
@@ -67,6 +67,7 @@
         <a href="/">Dashboard</a>
         <a href="/tasks">Tasks</a>
         <a href="/plan">Plan</a>
+        <a href="/kanban">Kanban</a>
     </nav>
     <main class="container">
         <h1>Project Dashboard</h1>

--- a/pkg/infrastructure/dashboard/templates/kanban.html
+++ b/pkg/infrastructure/dashboard/templates/kanban.html
@@ -1,0 +1,188 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Roady - Kanban</title>
+    <meta http-equiv="refresh" content="30">
+    <style>
+        :root {
+            --bg-primary: #1a1b26;
+            --bg-secondary: #24283b;
+            --bg-tertiary: #414868;
+            --bg-card: #2a2e44;
+            --text-primary: #c0caf5;
+            --text-secondary: #9aa5ce;
+            --text-muted: #565f89;
+            --accent-blue: #7aa2f7;
+            --accent-green: #9ece6a;
+            --accent-yellow: #e0af68;
+            --accent-red: #f7768e;
+            --accent-purple: #bb9af7;
+        }
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+        html, body { height: 100%; }
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            background: var(--bg-primary);
+            color: var(--text-primary);
+            line-height: 1.5;
+        }
+        nav {
+            background: var(--bg-secondary);
+            padding: 1rem 2rem;
+            border-bottom: 1px solid var(--bg-tertiary);
+        }
+        nav a { color: var(--text-secondary); text-decoration: none; margin-right: 2rem; }
+        nav a:hover { color: var(--accent-blue); }
+        .logo { font-weight: bold; font-size: 1.25rem; color: var(--accent-blue); margin-right: 2rem; }
+
+        .kanban-header {
+            padding: 1.5rem 2rem 0.5rem;
+            display: flex;
+            justify-content: space-between;
+            align-items: baseline;
+            gap: 1rem;
+            flex-wrap: wrap;
+        }
+        .kanban-header h1 { font-size: 1.5rem; }
+        .kanban-meta { color: var(--text-muted); font-size: 0.875rem; }
+
+        .board {
+            display: grid;
+            grid-template-columns: repeat(5, minmax(220px, 1fr));
+            gap: 0.75rem;
+            padding: 1rem 2rem 2rem;
+            align-items: start;
+            overflow-x: auto;
+        }
+        @media (max-width: 1100px) {
+            .board { grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); }
+        }
+
+        .column {
+            background: var(--bg-secondary);
+            border-radius: 8px;
+            padding: 0.75rem;
+            min-height: 200px;
+            display: flex;
+            flex-direction: column;
+            gap: 0.5rem;
+        }
+        .column-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--bg-tertiary);
+            margin-bottom: 0.25rem;
+        }
+        .column-title { font-weight: 600; font-size: 0.9rem; letter-spacing: 0.02em; text-transform: uppercase; }
+        .column-count {
+            background: var(--bg-tertiary);
+            color: var(--text-secondary);
+            padding: 0.1rem 0.5rem;
+            border-radius: 999px;
+            font-size: 0.75rem;
+            font-weight: 600;
+        }
+
+        /* Column accent stripes */
+        .col-backlog       .column-title { color: var(--text-secondary); }
+        .col-ready         .column-title { color: var(--accent-blue); }
+        .col-in_progress   .column-title { color: var(--accent-yellow); }
+        .col-blocked       .column-title { color: var(--accent-red); }
+        .col-done          .column-title { color: var(--accent-green); }
+
+        .card {
+            background: var(--bg-card);
+            border-left: 3px solid var(--bg-tertiary);
+            border-radius: 6px;
+            padding: 0.75rem 0.85rem;
+            font-size: 0.9rem;
+            display: flex;
+            flex-direction: column;
+            gap: 0.35rem;
+        }
+        .col-ready       .card { border-left-color: var(--accent-blue); }
+        .col-in_progress .card { border-left-color: var(--accent-yellow); }
+        .col-blocked     .card { border-left-color: var(--accent-red); }
+        .col-done        .card { border-left-color: var(--accent-green); }
+
+        .card-title { font-weight: 500; line-height: 1.3; word-break: break-word; }
+        .card-meta {
+            color: var(--text-muted);
+            font-size: 0.75rem;
+            display: flex;
+            gap: 0.75rem;
+            flex-wrap: wrap;
+            align-items: center;
+        }
+        .card-id { font-family: 'SF Mono', Menlo, monospace; }
+        .card-owner { color: var(--accent-purple); }
+        .card-deps { color: var(--text-muted); }
+        .card-empty { color: var(--text-muted); font-style: italic; font-size: 0.85rem; padding: 0.5rem 0; }
+
+        .error {
+            background: rgba(247, 118, 142, 0.1);
+            border: 1px solid var(--accent-red);
+            color: var(--accent-red);
+            padding: 1rem;
+            border-radius: 8px;
+            margin: 1rem 2rem;
+        }
+        footer { margin-top: 2rem; padding: 1.5rem; text-align: center; color: var(--text-muted); font-size: 0.8rem; }
+    </style>
+</head>
+<body>
+    <nav>
+        <span class="logo">Roady</span>
+        <a href="/">Dashboard</a>
+        <a href="/tasks">Tasks</a>
+        <a href="/plan">Plan</a>
+        <a href="/kanban">Kanban</a>
+    </nav>
+
+    {{if .Error}}
+        <div class="error">{{.Error}}</div>
+    {{else}}
+        <div class="kanban-header">
+            <h1>Kanban</h1>
+            <span class="kanban-meta">
+                {{.Board.TotalTasks}} task{{if ne .Board.TotalTasks 1}}s{{end}}
+                · updated {{.Board.UpdatedAt.Format "15:04:05"}}
+                · auto-refresh 30s
+                · <a href="/api/kanban" style="color: var(--text-muted)">JSON</a>
+            </span>
+        </div>
+
+        <div class="board">
+            {{range .Board.Columns}}
+            <section class="column col-{{.Status}}">
+                <header class="column-header">
+                    <span class="column-title">{{.Name}}</span>
+                    <span class="column-count">{{.Count}}</span>
+                </header>
+
+                {{if .Tasks}}
+                    {{range .Tasks}}
+                    <article class="card">
+                        <div class="card-title">{{.Task.Title}}</div>
+                        <div class="card-meta">
+                            <span class="card-id">{{.Task.ID}}</span>
+                            {{if .Owner}}<span class="card-owner">@{{.Owner}}</span>{{end}}
+                            {{if .Task.DependsOn}}<span class="card-deps">⛓ {{len .Task.DependsOn}} dep{{if ne (len .Task.DependsOn) 1}}s{{end}}</span>{{end}}
+                        </div>
+                    </article>
+                    {{end}}
+                {{else}}
+                    <div class="card-empty">—</div>
+                {{end}}
+            </section>
+            {{end}}
+        </div>
+    {{end}}
+
+    <footer>Roady Kanban · live view, refresh every 30s · <a href="/" style="color: var(--text-muted)">Back to dashboard</a></footer>
+</body>
+</html>

--- a/pkg/infrastructure/dashboard/templates/plan.html
+++ b/pkg/infrastructure/dashboard/templates/plan.html
@@ -49,6 +49,7 @@
         <a href="/">Dashboard</a>
         <a href="/tasks">Tasks</a>
         <a href="/plan">Plan</a>
+        <a href="/kanban">Kanban</a>
     </nav>
     <main class="container">
         <h1>Plan Details</h1>

--- a/pkg/infrastructure/dashboard/templates/tasks.html
+++ b/pkg/infrastructure/dashboard/templates/tasks.html
@@ -62,6 +62,7 @@
         <a href="/">Dashboard</a>
         <a href="/tasks">Tasks</a>
         <a href="/plan">Plan</a>
+        <a href="/kanban">Kanban</a>
     </nav>
     <main class="container">
         <h1>Tasks</h1>


### PR DESCRIPTION
## Summary

Adds a live Kanban view to the existing web dashboard at `/kanban` with five status columns:

**Backlog · Ready · In Progress · Blocked · Done**

- Pending tasks split into Backlog (unmet deps) vs Ready (deps satisfied), so the next-actionable work surfaces.
- Done rolls Verified into Done.
- Auto-refreshes every 30s (meta refresh).
- New JSON endpoint `/api/kanban` for IDE plugins / CI / external tools.
- Nav bar across dashboard pages gains a Kanban link.

Visualization-only first cut. Drag-drop / start / complete actions deferred to a follow-up so this PR stays small and focused.

## Try it

\`\`\`bash
roady dashboard serve --port 3000
open http://localhost:3000/kanban
\`\`\`

Or fetch the JSON:

\`\`\`bash
curl -s http://localhost:3000/api/kanban | jq
\`\`\`

## Test plan

- [x] Full \`go test ./...\` green (38 packages, 0 FAILs)
- [x] New unit tests in \`pkg/infrastructure/dashboard/kanban_test.go\` cover column order, dependency-aware Ready computation, Verified→Done collapse, empty-plan handling, stable task order, HTML rendering, JSON endpoint shape
- [x] \`golangci-lint run --new-from-rev=origin/main ./...\` clean
- [x] E2E against this repo's \`.roady/\` (33 tasks, 2 backlog / 4 ready / 1 in-progress / 3 blocked / 23 done)

## Out of scope (follow-up)

- Drag-drop or button-driven task transitions (start / complete / block)
- Cross-project Kanban (`/org/kanban`) once nested sub-projects accrue tasks
- SSE / WebSocket live updates instead of 30s meta refresh