### PR TITLE
feat(dashboard): cross-project Kanban at /org/kanban

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — Cross-project Kanban (`/org/kanban`)
+
+- New `/org/kanban` route on the dashboard renders every project under the workspace root — the root project plus every sub-project under `.roady/projects/<name>/` — merged into one five-column board.
+- Cards are tagged with their origin project label so it's clear which row each task belongs to.
+- New `/api/org/kanban` JSON endpoint exposes the same board for external tools.
+- Header strip lists every discovered project with task and done counts.
+- Auto-refreshes every 30s.
+
 ## [0.11.0] - 2026-05-16
 
 Adds two user-facing surfaces that lay the groundwork for an agent

--- a/internal/infrastructure/cli/dashboard.go
+++ b/internal/infrastructure/cli/dashboard.go
@@ -15,6 +15,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/felixgeelhaar/roady/internal/infrastructure/wiring"
+	"github.com/felixgeelhaar/roady/pkg/application"
 	"github.com/felixgeelhaar/roady/pkg/domain/planning"
 	"github.com/felixgeelhaar/roady/pkg/infrastructure/dashboard"
 	"github.com/spf13/cobra"
@@ -72,6 +73,10 @@ Access the dashboard in your browser at the displayed URL.`,
 			return fmt.Errorf("create server: %w", err)
 		}
 
+		// Wire cross-project Kanban over the workspace root so /org/kanban surfaces
+		// every project (root + sub-projects under .roady/projects/<name>/).
+		server.EnableOrgKanban(application.NewOrgService(services.Workspace.Repo.Root()), nil)
+
 		// Handle graceful shutdown
 		stop := make(chan os.Signal, 1)
 		signal.Notify(stop, syscall.SIGINT, syscall.SIGTERM)
@@ -112,6 +117,10 @@ var dashboardOpenCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("create server: %w", err)
 		}
+
+		// Wire cross-project Kanban over the workspace root so /org/kanban surfaces
+		// every project (root + sub-projects under .roady/projects/<name>/).
+		server.EnableOrgKanban(application.NewOrgService(services.Workspace.Repo.Root()), nil)
 
 		// Handle graceful shutdown
 		stop := make(chan os.Signal, 1)

--- a/pkg/infrastructure/dashboard/org_kanban.go
+++ b/pkg/infrastructure/dashboard/org_kanban.go
@@ -1,0 +1,170 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"net/http"
+	"path/filepath"
+	"sort"
+	"time"
+
+	"github.com/felixgeelhaar/roady/pkg/application"
+	"github.com/felixgeelhaar/roady/pkg/domain/planning"
+	"github.com/felixgeelhaar/roady/pkg/storage"
+)
+
+// OrgKanbanBoard is a cross-project Kanban board. Tasks from every discovered
+// project (root + sub-projects) are merged into the standard five columns,
+// each card tagged with its origin project label.
+type OrgKanbanBoard struct {
+	Columns    []KanbanColumn `json:"columns"`
+	Projects   []OrgKanbanRef `json:"projects"`
+	TotalTasks int            `json:"total_tasks"`
+	TotalDone  int            `json:"total_done"`
+	UpdatedAt  time.Time      `json:"updated_at"`
+	Err        string         `json:"error,omitempty"`
+}
+
+// OrgKanbanRef is a per-project rollup used in the header strip.
+type OrgKanbanRef struct {
+	Label      string `json:"label"`
+	Path       string `json:"path"`
+	SubProject string `json:"sub_project,omitempty"`
+	Total      int    `json:"total"`
+	Done       int    `json:"done"`
+}
+
+// OrgKanbanProvider supplies the discovery walker. In tests this is a fake;
+// in production the dashboard wires application.OrgService.
+type OrgKanbanProvider interface {
+	DiscoverProjectsWithSub() ([]application.DiscoveredProject, error)
+}
+
+// repoOpener constructs a storage repository for a discovered project. Split
+// out so tests can inject in-memory data.
+type repoOpener func(p application.DiscoveredProject) (*storage.FilesystemRepository, error)
+
+func defaultRepoOpener(p application.DiscoveredProject) (*storage.FilesystemRepository, error) {
+	return storage.NewFilesystemRepositoryForProject(p.Path, p.SubProject)
+}
+
+// buildOrgKanbanBoard discovers every project under root and aggregates their
+// plans+states into one cross-project board. Cards in each column are tagged
+// with a project label so the viewer can tell which task belongs where.
+func buildOrgKanbanBoard(prov OrgKanbanProvider, open repoOpener) OrgKanbanBoard {
+	if open == nil {
+		open = defaultRepoOpener
+	}
+	board := OrgKanbanBoard{UpdatedAt: time.Now()}
+
+	projects, err := prov.DiscoverProjectsWithSub()
+	if err != nil {
+		board.Err = err.Error()
+		for _, c := range kanbanColumnOrder {
+			board.Columns = append(board.Columns, KanbanColumn{Name: c.Name, Status: c.Status})
+		}
+		return board
+	}
+
+	cols := map[string]*KanbanColumn{}
+	for _, c := range kanbanColumnOrder {
+		cols[c.Status] = &KanbanColumn{Name: c.Name, Status: c.Status}
+	}
+
+	for _, p := range projects {
+		label := projectLabel(p)
+		repo, err := open(p)
+		if err != nil {
+			continue
+		}
+		plan, err := repo.LoadPlan()
+		if err != nil || plan == nil {
+			board.Projects = append(board.Projects, OrgKanbanRef{
+				Label: label, Path: repo.ProjectBase(), SubProject: p.SubProject,
+			})
+			continue
+		}
+		state, _ := repo.LoadState()
+
+		sub := buildKanbanBoard(plan, state)
+		// Merge sub-board tasks into the org columns, tagging each card with
+		// its project so consumers can disambiguate.
+		for _, sc := range sub.Columns {
+			for _, tv := range sc.Tasks {
+				tv.ProjectLabel = label
+				cols[sc.Status].Tasks = append(cols[sc.Status].Tasks, tv)
+			}
+		}
+		ref := OrgKanbanRef{
+			Label:      label,
+			Path:       repo.ProjectBase(),
+			SubProject: p.SubProject,
+			Total:      sub.TotalTasks,
+		}
+		for _, sc := range sub.Columns {
+			if sc.Status == string(planning.StatusDone) {
+				ref.Done = sc.Count
+			}
+		}
+		board.Projects = append(board.Projects, ref)
+	}
+
+	// Stable order within columns: project label, then task ID.
+	for _, c := range kanbanColumnOrder {
+		col := cols[c.Status]
+		sort.SliceStable(col.Tasks, func(i, j int) bool {
+			if col.Tasks[i].ProjectLabel != col.Tasks[j].ProjectLabel {
+				return col.Tasks[i].ProjectLabel < col.Tasks[j].ProjectLabel
+			}
+			return col.Tasks[i].Task.ID < col.Tasks[j].Task.ID
+		})
+		col.Count = len(col.Tasks)
+		board.Columns = append(board.Columns, *col)
+		board.TotalTasks += col.Count
+		if c.Status == string(planning.StatusDone) {
+			board.TotalDone = col.Count
+		}
+	}
+
+	sort.SliceStable(board.Projects, func(i, j int) bool {
+		return board.Projects[i].Label < board.Projects[j].Label
+	})
+	return board
+}
+
+func projectLabel(p application.DiscoveredProject) string {
+	base := filepath.Base(p.Path)
+	if p.SubProject == "" {
+		return base
+	}
+	return base + "/" + p.SubProject
+}
+
+// orgKanbanData is the template input.
+type orgKanbanData struct {
+	Title string
+	Board OrgKanbanBoard
+}
+
+// orgKanbanHandler returns an http.HandlerFunc bound to a provider+opener.
+// The dashboard server registers this when an OrgKanbanProvider is wired.
+func (s *Server) orgKanbanHandler(prov OrgKanbanProvider, open repoOpener) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		board := buildOrgKanbanBoard(prov, open)
+		s.render(w, "org_kanban.html", orgKanbanData{Title: "Org Kanban", Board: board})
+	}
+}
+
+func (s *Server) orgKanbanAPIHandler(prov OrgKanbanProvider, open repoOpener) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		board := buildOrgKanbanBoard(prov, open)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(board)
+	}
+}
+
+// EnableOrgKanban attaches the cross-project Kanban routes. Call before Start.
+// Pass nil for open to use the default filesystem repository constructor.
+func (s *Server) EnableOrgKanban(prov OrgKanbanProvider, open repoOpener) {
+	s.orgProvider = prov
+	s.orgRepoOpener = open
+}

--- a/pkg/infrastructure/dashboard/org_kanban_test.go
+++ b/pkg/infrastructure/dashboard/org_kanban_test.go
@@ -1,0 +1,209 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/felixgeelhaar/roady/pkg/application"
+	"github.com/felixgeelhaar/roady/pkg/domain/planning"
+	"github.com/felixgeelhaar/roady/pkg/domain/spec"
+	"github.com/felixgeelhaar/roady/pkg/storage"
+)
+
+// stubOrgProvider implements OrgKanbanProvider for tests.
+type stubOrgProvider struct {
+	items []application.DiscoveredProject
+}
+
+func (s *stubOrgProvider) DiscoverProjectsWithSub() ([]application.DiscoveredProject, error) {
+	return s.items, nil
+}
+
+// initSubProject creates a sub-project with a plan + state. Returns the
+// discovered-project descriptor matching it.
+func initSubProject(t *testing.T, root, name string, tasks []planning.Task, states map[string]planning.TaskResult) application.DiscoveredProject {
+	t.Helper()
+	repo, err := storage.NewFilesystemRepositoryForProject(root, name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.Initialize(); err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.SaveSpec(&spec.ProductSpec{ID: "s-" + name, Title: name}); err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.SavePlan(&planning.Plan{ID: "p-" + name, Tasks: tasks}); err != nil {
+		t.Fatal(err)
+	}
+	if states != nil {
+		if err := repo.SaveState(&planning.ExecutionState{TaskStates: states}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return application.DiscoveredProject{Path: root, SubProject: name}
+}
+
+func TestBuildOrgKanbanBoard_MergesAcrossProjects(t *testing.T) {
+	root := t.TempDir()
+
+	auth := initSubProject(t, root, "auth",
+		[]planning.Task{
+			{ID: "auth-1", Title: "ready"},
+			{ID: "auth-2", Title: "wip"},
+		},
+		map[string]planning.TaskResult{
+			"auth-2": {Status: planning.StatusInProgress, Owner: "alice"},
+		},
+	)
+	billing := initSubProject(t, root, "billing",
+		[]planning.Task{
+			{ID: "bill-1", Title: "done"},
+			{ID: "bill-2", Title: "blocked"},
+		},
+		map[string]planning.TaskResult{
+			"bill-1": {Status: planning.StatusDone},
+			"bill-2": {Status: planning.StatusBlocked},
+		},
+	)
+
+	prov := &stubOrgProvider{items: []application.DiscoveredProject{auth, billing}}
+	board := buildOrgKanbanBoard(prov, defaultRepoOpener)
+
+	if board.TotalTasks != 4 {
+		t.Errorf("TotalTasks = %d, want 4", board.TotalTasks)
+	}
+	if board.TotalDone != 1 {
+		t.Errorf("TotalDone = %d, want 1", board.TotalDone)
+	}
+	if len(board.Projects) != 2 {
+		t.Fatalf("Projects = %d, want 2", len(board.Projects))
+	}
+
+	wantCount := map[string]int{
+		"backlog":                         0,
+		"ready":                           1, // auth-1
+		string(planning.StatusInProgress): 1,
+		string(planning.StatusBlocked):    1,
+		string(planning.StatusDone):       1,
+	}
+	for _, c := range board.Columns {
+		if got, want := c.Count, wantCount[c.Status]; got != want {
+			t.Errorf("column %q count = %d, want %d", c.Status, got, want)
+		}
+	}
+
+	// Each card carries a project label.
+	for _, c := range board.Columns {
+		for _, tv := range c.Tasks {
+			if tv.ProjectLabel == "" {
+				t.Errorf("card %s missing ProjectLabel", tv.Task.ID)
+			}
+		}
+	}
+}
+
+func TestBuildOrgKanbanBoard_ProjectLabelIncludesSubProject(t *testing.T) {
+	root := t.TempDir()
+	d := initSubProject(t, root, "auth", []planning.Task{{ID: "x"}}, nil)
+
+	prov := &stubOrgProvider{items: []application.DiscoveredProject{d}}
+	board := buildOrgKanbanBoard(prov, defaultRepoOpener)
+
+	if len(board.Projects) != 1 {
+		t.Fatalf("Projects = %d, want 1", len(board.Projects))
+	}
+	wantLabel := filepath.Base(root) + "/auth"
+	if board.Projects[0].Label != wantLabel {
+		t.Errorf("Project label = %q, want %q", board.Projects[0].Label, wantLabel)
+	}
+}
+
+func TestBuildOrgKanbanBoard_MissingPlanCountsProjectButNoTasks(t *testing.T) {
+	root := t.TempDir()
+	// Project initialised but no plan saved.
+	repo, err := storage.NewFilesystemRepositoryForProject(root, "empty")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.Initialize(); err != nil {
+		t.Fatal(err)
+	}
+	d := application.DiscoveredProject{Path: root, SubProject: "empty"}
+
+	prov := &stubOrgProvider{items: []application.DiscoveredProject{d}}
+	board := buildOrgKanbanBoard(prov, defaultRepoOpener)
+
+	if board.TotalTasks != 0 {
+		t.Errorf("TotalTasks = %d, want 0", board.TotalTasks)
+	}
+	if len(board.Projects) != 1 {
+		t.Errorf("Projects = %d, want 1", len(board.Projects))
+	}
+}
+
+func TestBuildOrgKanbanBoard_DiscoveryError(t *testing.T) {
+	prov := failingOrgProvider{}
+	board := buildOrgKanbanBoard(prov, defaultRepoOpener)
+	if board.Err == "" {
+		t.Error("expected Err to be set on discovery failure")
+	}
+	if len(board.Columns) != 5 {
+		t.Errorf("columns = %d, want 5 empty", len(board.Columns))
+	}
+}
+
+type failingOrgProvider struct{}
+
+func (failingOrgProvider) DiscoverProjectsWithSub() ([]application.DiscoveredProject, error) {
+	return nil, os.ErrPermission
+}
+
+func TestOrgKanbanRoutesRegisteredWhenEnabled(t *testing.T) {
+	root := t.TempDir()
+	d := initSubProject(t, root, "auth",
+		[]planning.Task{{ID: "auth-1", Title: "ready"}},
+		nil,
+	)
+
+	srv, err := NewServer(":0", &kanbanStubProvider{plan: &planning.Plan{}, state: &planning.ExecutionState{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv.EnableOrgKanban(&stubOrgProvider{items: []application.DiscoveredProject{d}}, nil)
+
+	// HTML
+	rec := httptest.NewRecorder()
+	srv.orgKanbanHandler(srv.orgProvider, srv.orgRepoOpener)(rec, httptest.NewRequest(http.MethodGet, "/org/kanban", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("html status = %d", rec.Code)
+	}
+	body := rec.Body.String()
+	for _, want := range []string{"Org Kanban", "auth", "auth-1"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("body missing %q", want)
+		}
+	}
+
+	// JSON
+	rec = httptest.NewRecorder()
+	srv.orgKanbanAPIHandler(srv.orgProvider, srv.orgRepoOpener)(rec, httptest.NewRequest(http.MethodGet, "/api/org/kanban", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("api status = %d", rec.Code)
+	}
+	if got := rec.Header().Get("Content-Type"); got != "application/json" {
+		t.Errorf("content-type = %q, want application/json", got)
+	}
+	var board OrgKanbanBoard
+	if err := json.Unmarshal(rec.Body.Bytes(), &board); err != nil {
+		t.Fatalf("json decode: %v", err)
+	}
+	if len(board.Projects) != 1 {
+		t.Errorf("Projects = %d, want 1", len(board.Projects))
+	}
+}

--- a/pkg/infrastructure/dashboard/server.go
+++ b/pkg/infrastructure/dashboard/server.go
@@ -29,6 +29,11 @@ type Server struct {
 	provider DataProvider
 	server   *http.Server
 	tmpl     *template.Template
+
+	// Optional cross-project Kanban wiring. When set, /org/kanban routes are
+	// registered. See EnableOrgKanban.
+	orgProvider   OrgKanbanProvider
+	orgRepoOpener repoOpener
 }
 
 // NewServer creates a new dashboard server.
@@ -63,6 +68,11 @@ func (s *Server) Start() error {
 	mux.HandleFunc("GET /api/state", s.handleAPIState)
 	mux.HandleFunc("GET /api/kanban", s.handleAPIKanban)
 
+	if s.orgProvider != nil {
+		mux.HandleFunc("GET /org/kanban", s.orgKanbanHandler(s.orgProvider, s.orgRepoOpener))
+		mux.HandleFunc("GET /api/org/kanban", s.orgKanbanAPIHandler(s.orgProvider, s.orgRepoOpener))
+	}
+
 	s.server = &http.Server{
 		Addr:         s.addr,
 		Handler:      mux,
@@ -94,10 +104,11 @@ type PageData struct {
 
 // TaskView combines task and state info for display.
 type TaskView struct {
-	Task     planning.Task
-	Status   planning.TaskStatus
-	Owner    string
-	HasLinks bool
+	Task         planning.Task
+	Status       planning.TaskStatus
+	Owner        string
+	HasLinks     bool
+	ProjectLabel string // set on cross-project Kanban cards; empty for per-project views
 }
 
 // DashboardStats holds summary statistics.

--- a/pkg/infrastructure/dashboard/templates/index.html
+++ b/pkg/infrastructure/dashboard/templates/index.html
@@ -68,6 +68,7 @@
         <a href="/tasks">Tasks</a>
         <a href="/plan">Plan</a>
         <a href="/kanban">Kanban</a>
+        <a href="/org/kanban">Org Kanban</a>
     </nav>
     <main class="container">
         <h1>Project Dashboard</h1>

--- a/pkg/infrastructure/dashboard/templates/kanban.html
+++ b/pkg/infrastructure/dashboard/templates/kanban.html
@@ -141,6 +141,7 @@
         <a href="/tasks">Tasks</a>
         <a href="/plan">Plan</a>
         <a href="/kanban">Kanban</a>
+        <a href="/org/kanban">Org Kanban</a>
     </nav>
 
     {{if .Error}}

--- a/pkg/infrastructure/dashboard/templates/org_kanban.html
+++ b/pkg/infrastructure/dashboard/templates/org_kanban.html
@@ -1,0 +1,144 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Roady - Org Kanban</title>
+    <meta http-equiv="refresh" content="30">
+    <style>
+        :root {
+            --bg-primary: #1a1b26;
+            --bg-secondary: #24283b;
+            --bg-tertiary: #414868;
+            --bg-card: #2a2e44;
+            --text-primary: #c0caf5;
+            --text-secondary: #9aa5ce;
+            --text-muted: #565f89;
+            --accent-blue: #7aa2f7;
+            --accent-green: #9ece6a;
+            --accent-yellow: #e0af68;
+            --accent-red: #f7768e;
+            --accent-purple: #bb9af7;
+            --accent-cyan: #7dcfff;
+        }
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+        html, body { height: 100%; }
+        body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: var(--bg-primary); color: var(--text-primary); line-height: 1.5; }
+        nav { background: var(--bg-secondary); padding: 1rem 2rem; border-bottom: 1px solid var(--bg-tertiary); }
+        nav a { color: var(--text-secondary); text-decoration: none; margin-right: 2rem; }
+        nav a:hover { color: var(--accent-blue); }
+        .logo { font-weight: bold; font-size: 1.25rem; color: var(--accent-blue); margin-right: 2rem; }
+
+        .header { padding: 1.5rem 2rem 0.5rem; display: flex; justify-content: space-between; align-items: baseline; gap: 1rem; flex-wrap: wrap; }
+        .header h1 { font-size: 1.5rem; }
+        .meta { color: var(--text-muted); font-size: 0.875rem; }
+
+        .project-strip { display: flex; flex-wrap: wrap; gap: 0.5rem; padding: 0 2rem 1rem; }
+        .project-chip {
+            background: var(--bg-secondary);
+            border: 1px solid var(--bg-tertiary);
+            padding: 0.4rem 0.7rem;
+            border-radius: 999px;
+            font-size: 0.8rem;
+            color: var(--text-secondary);
+            display: inline-flex;
+            gap: 0.5rem;
+            align-items: center;
+        }
+        .project-chip strong { color: var(--text-primary); }
+        .project-chip .done { color: var(--accent-green); font-weight: 600; }
+
+        .board { display: grid; grid-template-columns: repeat(5, minmax(220px, 1fr)); gap: 0.75rem; padding: 0 2rem 2rem; align-items: start; overflow-x: auto; }
+        @media (max-width: 1100px) { .board { grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); } }
+
+        .column { background: var(--bg-secondary); border-radius: 8px; padding: 0.75rem; min-height: 200px; display: flex; flex-direction: column; gap: 0.5rem; }
+        .column-header { display: flex; justify-content: space-between; align-items: center; padding-bottom: 0.5rem; border-bottom: 1px solid var(--bg-tertiary); margin-bottom: 0.25rem; }
+        .column-title { font-weight: 600; font-size: 0.9rem; letter-spacing: 0.02em; text-transform: uppercase; }
+        .column-count { background: var(--bg-tertiary); color: var(--text-secondary); padding: 0.1rem 0.5rem; border-radius: 999px; font-size: 0.75rem; font-weight: 600; }
+
+        .col-backlog       .column-title { color: var(--text-secondary); }
+        .col-ready         .column-title { color: var(--accent-blue); }
+        .col-in_progress   .column-title { color: var(--accent-yellow); }
+        .col-blocked       .column-title { color: var(--accent-red); }
+        .col-done          .column-title { color: var(--accent-green); }
+
+        .card { background: var(--bg-card); border-left: 3px solid var(--bg-tertiary); border-radius: 6px; padding: 0.65rem 0.8rem; font-size: 0.88rem; display: flex; flex-direction: column; gap: 0.3rem; }
+        .col-ready       .card { border-left-color: var(--accent-blue); }
+        .col-in_progress .card { border-left-color: var(--accent-yellow); }
+        .col-blocked     .card { border-left-color: var(--accent-red); }
+        .col-done        .card { border-left-color: var(--accent-green); }
+
+        .card-project { font-size: 0.7rem; color: var(--accent-cyan); font-family: 'SF Mono', Menlo, monospace; letter-spacing: 0.02em; }
+        .card-title { font-weight: 500; line-height: 1.3; word-break: break-word; }
+        .card-meta { color: var(--text-muted); font-size: 0.72rem; display: flex; gap: 0.6rem; flex-wrap: wrap; align-items: center; }
+        .card-id { font-family: 'SF Mono', Menlo, monospace; }
+        .card-owner { color: var(--accent-purple); }
+        .card-empty { color: var(--text-muted); font-style: italic; font-size: 0.85rem; padding: 0.5rem 0; }
+
+        .error { background: rgba(247, 118, 142, 0.1); border: 1px solid var(--accent-red); color: var(--accent-red); padding: 1rem; border-radius: 8px; margin: 1rem 2rem; }
+        footer { margin-top: 2rem; padding: 1.5rem; text-align: center; color: var(--text-muted); font-size: 0.8rem; }
+    </style>
+</head>
+<body>
+    <nav>
+        <span class="logo">Roady</span>
+        <a href="/">Dashboard</a>
+        <a href="/tasks">Tasks</a>
+        <a href="/plan">Plan</a>
+        <a href="/kanban">Kanban</a>
+        <a href="/org/kanban">Org Kanban</a>
+    </nav>
+
+    {{if .Board.Err}}
+        <div class="error">{{.Board.Err}}</div>
+    {{end}}
+
+    <div class="header">
+        <h1>Org Kanban</h1>
+        <span class="meta">
+            {{len .Board.Projects}} project{{if ne (len .Board.Projects) 1}}s{{end}}
+            · {{.Board.TotalTasks}} task{{if ne .Board.TotalTasks 1}}s{{end}}
+            · {{.Board.TotalDone}} done
+            · updated {{.Board.UpdatedAt.Format "15:04:05"}}
+            · auto-refresh 30s
+            · <a href="/api/org/kanban" style="color: var(--text-muted)">JSON</a>
+        </span>
+    </div>
+
+    {{if .Board.Projects}}
+    <div class="project-strip">
+        {{range .Board.Projects}}
+        <span class="project-chip"><strong>{{.Label}}</strong> · {{.Total}} task{{if ne .Total 1}}s{{end}} · <span class="done">{{.Done}} done</span></span>
+        {{end}}
+    </div>
+    {{end}}
+
+    <div class="board">
+        {{range .Board.Columns}}
+        <section class="column col-{{.Status}}">
+            <header class="column-header">
+                <span class="column-title">{{.Name}}</span>
+                <span class="column-count">{{.Count}}</span>
+            </header>
+
+            {{if .Tasks}}
+                {{range .Tasks}}
+                <article class="card">
+                    {{if .ProjectLabel}}<div class="card-project">{{.ProjectLabel}}</div>{{end}}
+                    <div class="card-title">{{.Task.Title}}</div>
+                    <div class="card-meta">
+                        <span class="card-id">{{.Task.ID}}</span>
+                        {{if .Owner}}<span class="card-owner">@{{.Owner}}</span>{{end}}
+                    </div>
+                </article>
+                {{end}}
+            {{else}}
+                <div class="card-empty">—</div>
+            {{end}}
+        </section>
+        {{end}}
+    </div>
+
+    <footer>Roady Org Kanban · live cross-project view · <a href="/kanban" style="color: var(--text-muted)">single project</a></footer>
+</body>
+</html>

--- a/pkg/infrastructure/dashboard/templates/plan.html
+++ b/pkg/infrastructure/dashboard/templates/plan.html
@@ -50,6 +50,7 @@
         <a href="/tasks">Tasks</a>
         <a href="/plan">Plan</a>
         <a href="/kanban">Kanban</a>
+        <a href="/org/kanban">Org Kanban</a>
     </nav>
     <main class="container">
         <h1>Plan Details</h1>

--- a/pkg/infrastructure/dashboard/templates/tasks.html
+++ b/pkg/infrastructure/dashboard/templates/tasks.html
@@ -63,6 +63,7 @@
         <a href="/tasks">Tasks</a>
         <a href="/plan">Plan</a>
         <a href="/kanban">Kanban</a>
+        <a href="/org/kanban">Org Kanban</a>
     </nav>
     <main class="container">
         <h1>Tasks</h1>


### PR DESCRIPTION
## Summary

Adds \`/org/kanban\` — one cross-project Kanban board merging every project under the workspace root (root + sub-projects from v0.11.0's nested-projects feature) into a single five-column view.

Cards are tagged with their origin project label so a viewer always knows where each task belongs.

- New \`/org/kanban\` HTML route + \`/api/org/kanban\` JSON endpoint.
- Header strip lists every discovered project with task / done counts.
- 30s auto-refresh.
- Wired automatically by \`roady dashboard serve\` — no extra flags.
- Nav across dashboard pages gains an \"Org Kanban\" link.

## Try it

\`\`\`bash
roady init --template minimal              # root project
roady -P feature-auth     init -t minimal
roady -P feature-payments init -t minimal
roady dashboard serve --port 3000
open http://localhost:3000/org/kanban
\`\`\`

## Test plan

- [x] 5 new unit tests in \`org_kanban_test.go\` (merge across projects, project label format, missing plan handling, discovery error, end-to-end HTML+JSON routing)
- [x] Full \`go test ./...\` green (43 packages, 0 FAILs)
- [x] \`golangci-lint run --new-from-rev=origin/main ./...\` clean
- [x] E2E against a temp repo with 1 root + 2 sub-projects; \`/api/org/kanban\` returns all three with correct labels

## Out of scope (follow-up)

- Per-project drill-down from a card click
- SSE updates instead of meta-refresh
- Task transitions (start/complete/block) from the board