### PR TITLE
feat(dashboard): interactive Kanban — task action buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — Interactive Kanban (task action buttons)
+
+- The `/kanban` board is no longer read-only. Cards now render contextual buttons by column: **Ready → Start**, **In Progress → Complete / Block**, **Blocked → Unblock**.
+- New POST endpoints: `/actions/task/start`, `/actions/task/complete`, `/actions/task/block`, `/actions/task/unblock`. Form-encoded, sender redirected back to the referring page.
+- Wired automatically by `roady dashboard serve` via the existing `TaskService`. No extra flags.
+- Backward-compatible: if a custom server is constructed without `EnableTaskActions`, the action routes stay unregistered and the board is read-only.
+
 ## [0.11.1] - 2026-05-16
 
 Adds the cross-project Kanban view that ties together v0.11.0's nested

--- a/internal/infrastructure/cli/dashboard.go
+++ b/internal/infrastructure/cli/dashboard.go
@@ -76,6 +76,9 @@ Access the dashboard in your browser at the displayed URL.`,
 		// Wire cross-project Kanban over the workspace root so /org/kanban surfaces
 		// every project (root + sub-projects under .roady/projects/<name>/).
 		server.EnableOrgKanban(application.NewOrgService(services.Workspace.Repo.Root()), nil)
+		// Wire task-action buttons (Start / Complete / Block / Unblock) on the
+		// per-project Kanban board.
+		server.EnableTaskActions(services.Task)
 
 		// Handle graceful shutdown
 		stop := make(chan os.Signal, 1)
@@ -121,6 +124,9 @@ var dashboardOpenCmd = &cobra.Command{
 		// Wire cross-project Kanban over the workspace root so /org/kanban surfaces
 		// every project (root + sub-projects under .roady/projects/<name>/).
 		server.EnableOrgKanban(application.NewOrgService(services.Workspace.Repo.Root()), nil)
+		// Wire task-action buttons (Start / Complete / Block / Unblock) on the
+		// per-project Kanban board.
+		server.EnableTaskActions(services.Task)
 
 		// Handle graceful shutdown
 		stop := make(chan os.Signal, 1)

--- a/pkg/infrastructure/dashboard/actions.go
+++ b/pkg/infrastructure/dashboard/actions.go
@@ -1,0 +1,127 @@
+package dashboard
+
+import (
+	"context"
+	"net/http"
+)
+
+// TaskActions exposes the subset of TaskService methods the Kanban board
+// needs to mutate task state. The dashboard server takes this as an optional
+// dependency; when nil, the action endpoints stay unregistered and the board
+// is read-only.
+type TaskActions interface {
+	StartTask(ctx context.Context, taskID, owner, rateID string) error
+	CompleteTask(ctx context.Context, taskID, evidence string) ([]string, error)
+	BlockTask(ctx context.Context, taskID, reason string) error
+	UnblockTask(ctx context.Context, taskID string) error
+}
+
+// EnableTaskActions wires POST handlers that mutate task state from the
+// dashboard (Kanban card buttons). Pass nil to keep the board read-only.
+func (s *Server) EnableTaskActions(svc TaskActions) {
+	s.taskActions = svc
+}
+
+// redirectAfterAction sends the user back to the page they came from
+// (Referer when set, /kanban as a sane default).
+func redirectAfterAction(w http.ResponseWriter, r *http.Request) {
+	dest := r.Header.Get("Referer")
+	if dest == "" {
+		dest = "/kanban"
+	}
+	http.Redirect(w, r, dest, http.StatusSeeOther)
+}
+
+func (s *Server) handleTaskStart(w http.ResponseWriter, r *http.Request) {
+	if s.taskActions == nil {
+		http.Error(w, "task actions not enabled", http.StatusServiceUnavailable)
+		return
+	}
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	id := r.PostForm.Get("id")
+	if id == "" {
+		http.Error(w, "missing task id", http.StatusBadRequest)
+		return
+	}
+	owner := strDefault(r.PostForm.Get("owner"), "dashboard")
+	if err := s.taskActions.StartTask(r.Context(), id, owner, ""); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	redirectAfterAction(w, r)
+}
+
+func (s *Server) handleTaskComplete(w http.ResponseWriter, r *http.Request) {
+	if s.taskActions == nil {
+		http.Error(w, "task actions not enabled", http.StatusServiceUnavailable)
+		return
+	}
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	id := r.PostForm.Get("id")
+	if id == "" {
+		http.Error(w, "missing task id", http.StatusBadRequest)
+		return
+	}
+	evidence := strDefault(r.PostForm.Get("evidence"), "completed via dashboard")
+	if _, err := s.taskActions.CompleteTask(r.Context(), id, evidence); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	redirectAfterAction(w, r)
+}
+
+func (s *Server) handleTaskBlock(w http.ResponseWriter, r *http.Request) {
+	if s.taskActions == nil {
+		http.Error(w, "task actions not enabled", http.StatusServiceUnavailable)
+		return
+	}
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	id := r.PostForm.Get("id")
+	if id == "" {
+		http.Error(w, "missing task id", http.StatusBadRequest)
+		return
+	}
+	reason := strDefault(r.PostForm.Get("reason"), "blocked via dashboard")
+	if err := s.taskActions.BlockTask(r.Context(), id, reason); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	redirectAfterAction(w, r)
+}
+
+func (s *Server) handleTaskUnblock(w http.ResponseWriter, r *http.Request) {
+	if s.taskActions == nil {
+		http.Error(w, "task actions not enabled", http.StatusServiceUnavailable)
+		return
+	}
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	id := r.PostForm.Get("id")
+	if id == "" {
+		http.Error(w, "missing task id", http.StatusBadRequest)
+		return
+	}
+	if err := s.taskActions.UnblockTask(r.Context(), id); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	redirectAfterAction(w, r)
+}
+
+func strDefault(v, def string) string {
+	if v == "" {
+		return def
+	}
+	return v
+}

--- a/pkg/infrastructure/dashboard/actions_test.go
+++ b/pkg/infrastructure/dashboard/actions_test.go
@@ -1,0 +1,198 @@
+package dashboard
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/felixgeelhaar/roady/pkg/domain/planning"
+)
+
+type fakeTaskActions struct {
+	startCalled    *startArgs
+	completeCalled *completeArgs
+	blockCalled    *blockArgs
+	unblockCalled  *unblockArgs
+
+	startErr    error
+	completeErr error
+	blockErr    error
+	unblockErr  error
+}
+
+type startArgs struct{ id, owner, rateID string }
+type completeArgs struct{ id, evidence string }
+type blockArgs struct{ id, reason string }
+type unblockArgs struct{ id string }
+
+func (f *fakeTaskActions) StartTask(ctx context.Context, id, owner, rateID string) error {
+	f.startCalled = &startArgs{id, owner, rateID}
+	return f.startErr
+}
+func (f *fakeTaskActions) CompleteTask(ctx context.Context, id, evidence string) ([]string, error) {
+	f.completeCalled = &completeArgs{id, evidence}
+	return nil, f.completeErr
+}
+func (f *fakeTaskActions) BlockTask(ctx context.Context, id, reason string) error {
+	f.blockCalled = &blockArgs{id, reason}
+	return f.blockErr
+}
+func (f *fakeTaskActions) UnblockTask(ctx context.Context, id string) error {
+	f.unblockCalled = &unblockArgs{id}
+	return f.unblockErr
+}
+
+func newActionsServer(t *testing.T, actions TaskActions) *Server {
+	t.Helper()
+	srv, err := NewServer(":0", &kanbanStubProvider{plan: &planning.Plan{}, state: &planning.ExecutionState{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if actions != nil {
+		srv.EnableTaskActions(actions)
+	}
+	return srv
+}
+
+func postForm(t *testing.T, h http.HandlerFunc, path string, form url.Values) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Referer", "/kanban")
+	rec := httptest.NewRecorder()
+	h(rec, req)
+	return rec
+}
+
+func TestHandleTaskStart_HappyPath(t *testing.T) {
+	a := &fakeTaskActions{}
+	srv := newActionsServer(t, a)
+
+	rec := postForm(t, srv.handleTaskStart, "/actions/task/start", url.Values{"id": {"t-1"}, "owner": {"alice"}})
+
+	if rec.Code != http.StatusSeeOther {
+		t.Errorf("status = %d, want 303", rec.Code)
+	}
+	if a.startCalled == nil || a.startCalled.id != "t-1" || a.startCalled.owner != "alice" {
+		t.Errorf("StartTask call = %+v, want {t-1 alice}", a.startCalled)
+	}
+	if got := rec.Header().Get("Location"); got != "/kanban" {
+		t.Errorf("redirect to %q, want /kanban", got)
+	}
+}
+
+func TestHandleTaskStart_DefaultOwner(t *testing.T) {
+	a := &fakeTaskActions{}
+	srv := newActionsServer(t, a)
+	postForm(t, srv.handleTaskStart, "/actions/task/start", url.Values{"id": {"t-1"}})
+	if a.startCalled.owner != "dashboard" {
+		t.Errorf("default owner = %q, want dashboard", a.startCalled.owner)
+	}
+}
+
+func TestHandleTaskStart_MissingID(t *testing.T) {
+	srv := newActionsServer(t, &fakeTaskActions{})
+	rec := postForm(t, srv.handleTaskStart, "/actions/task/start", url.Values{})
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", rec.Code)
+	}
+}
+
+func TestHandleTaskComplete_HappyPath(t *testing.T) {
+	a := &fakeTaskActions{}
+	srv := newActionsServer(t, a)
+	rec := postForm(t, srv.handleTaskComplete, "/actions/task/complete", url.Values{"id": {"t-2"}, "evidence": {"PR #99"}})
+	if rec.Code != http.StatusSeeOther {
+		t.Errorf("status = %d", rec.Code)
+	}
+	if a.completeCalled == nil || a.completeCalled.id != "t-2" || a.completeCalled.evidence != "PR #99" {
+		t.Errorf("CompleteTask call = %+v", a.completeCalled)
+	}
+}
+
+func TestHandleTaskBlock_HappyPath(t *testing.T) {
+	a := &fakeTaskActions{}
+	srv := newActionsServer(t, a)
+	rec := postForm(t, srv.handleTaskBlock, "/actions/task/block", url.Values{"id": {"t-3"}, "reason": {"waiting on legal"}})
+	if rec.Code != http.StatusSeeOther {
+		t.Errorf("status = %d", rec.Code)
+	}
+	if a.blockCalled == nil || a.blockCalled.id != "t-3" || a.blockCalled.reason != "waiting on legal" {
+		t.Errorf("BlockTask call = %+v", a.blockCalled)
+	}
+}
+
+func TestHandleTaskUnblock_HappyPath(t *testing.T) {
+	a := &fakeTaskActions{}
+	srv := newActionsServer(t, a)
+	rec := postForm(t, srv.handleTaskUnblock, "/actions/task/unblock", url.Values{"id": {"t-4"}})
+	if rec.Code != http.StatusSeeOther {
+		t.Errorf("status = %d", rec.Code)
+	}
+	if a.unblockCalled == nil || a.unblockCalled.id != "t-4" {
+		t.Errorf("UnblockTask call = %+v", a.unblockCalled)
+	}
+}
+
+func TestHandlers_TaskActionsDisabled(t *testing.T) {
+	srv := newActionsServer(t, nil) // no actions wired
+	for _, tc := range []struct {
+		name string
+		h    http.HandlerFunc
+		path string
+	}{
+		{"start", srv.handleTaskStart, "/actions/task/start"},
+		{"complete", srv.handleTaskComplete, "/actions/task/complete"},
+		{"block", srv.handleTaskBlock, "/actions/task/block"},
+		{"unblock", srv.handleTaskUnblock, "/actions/task/unblock"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := postForm(t, tc.h, tc.path, url.Values{"id": {"x"}})
+			if rec.Code != http.StatusServiceUnavailable {
+				t.Errorf("status = %d, want 503 when actions disabled", rec.Code)
+			}
+		})
+	}
+}
+
+func TestHandlers_ServiceError(t *testing.T) {
+	a := &fakeTaskActions{startErr: errors.New("nope")}
+	srv := newActionsServer(t, a)
+	rec := postForm(t, srv.handleTaskStart, "/actions/task/start", url.Values{"id": {"t-1"}})
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400 on service error", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "nope") {
+		t.Errorf("body missing service error: %q", rec.Body.String())
+	}
+}
+
+func TestHandlers_RedirectFallback(t *testing.T) {
+	a := &fakeTaskActions{}
+	srv := newActionsServer(t, a)
+	req := httptest.NewRequest(http.MethodPost, "/actions/task/start", strings.NewReader(url.Values{"id": {"t-1"}}.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	// no Referer header
+	rec := httptest.NewRecorder()
+	srv.handleTaskStart(rec, req)
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	if got := rec.Header().Get("Location"); got != "/kanban" {
+		t.Errorf("default redirect = %q, want /kanban", got)
+	}
+}
+
+// Compile-time guard: the Server has the expected method.
+var _ = func() {
+	var s Server
+	s.EnableTaskActions(nil)
+}
+
+// pretty-print helper for debug.
+var _ = fmt.Stringer(nil)

--- a/pkg/infrastructure/dashboard/kanban.go
+++ b/pkg/infrastructure/dashboard/kanban.go
@@ -134,13 +134,14 @@ func dependenciesMet(task planning.Task, byID map[string]planning.TaskStatus) bo
 // kanbanData wraps the board plus standard PageData so templates can share
 // the layout with other dashboard pages.
 type kanbanData struct {
-	Title string
-	Board KanbanBoard
-	Error string
+	Title          string
+	Board          KanbanBoard
+	Error          string
+	ActionsEnabled bool
 }
 
 func (s *Server) handleKanban(w http.ResponseWriter, r *http.Request) {
-	data := kanbanData{Title: "Kanban"}
+	data := kanbanData{Title: "Kanban", ActionsEnabled: s.taskActions != nil}
 
 	plan, err := s.provider.GetPlan()
 	if err != nil {

--- a/pkg/infrastructure/dashboard/server.go
+++ b/pkg/infrastructure/dashboard/server.go
@@ -34,6 +34,10 @@ type Server struct {
 	// registered. See EnableOrgKanban.
 	orgProvider   OrgKanbanProvider
 	orgRepoOpener repoOpener
+
+	// Optional task-action wiring. When set, POST /actions/task/* routes are
+	// registered and the Kanban board renders action buttons. See EnableTaskActions.
+	taskActions TaskActions
 }
 
 // NewServer creates a new dashboard server.
@@ -71,6 +75,13 @@ func (s *Server) Start() error {
 	if s.orgProvider != nil {
 		mux.HandleFunc("GET /org/kanban", s.orgKanbanHandler(s.orgProvider, s.orgRepoOpener))
 		mux.HandleFunc("GET /api/org/kanban", s.orgKanbanAPIHandler(s.orgProvider, s.orgRepoOpener))
+	}
+
+	if s.taskActions != nil {
+		mux.HandleFunc("POST /actions/task/start", s.handleTaskStart)
+		mux.HandleFunc("POST /actions/task/complete", s.handleTaskComplete)
+		mux.HandleFunc("POST /actions/task/block", s.handleTaskBlock)
+		mux.HandleFunc("POST /actions/task/unblock", s.handleTaskUnblock)
 	}
 
 	s.server = &http.Server{

--- a/pkg/infrastructure/dashboard/templates/kanban.html
+++ b/pkg/infrastructure/dashboard/templates/kanban.html
@@ -123,6 +123,30 @@
         .card-deps { color: var(--text-muted); }
         .card-empty { color: var(--text-muted); font-style: italic; font-size: 0.85rem; padding: 0.5rem 0; }
 
+        .card-actions { display: flex; gap: 0.4rem; margin-top: 0.3rem; flex-wrap: wrap; }
+        .card-actions form { display: inline; margin: 0; }
+        .btn {
+            background: var(--bg-tertiary);
+            color: var(--text-primary);
+            border: none;
+            border-radius: 4px;
+            padding: 0.25rem 0.6rem;
+            font-size: 0.72rem;
+            font-weight: 500;
+            cursor: pointer;
+            font-family: inherit;
+            transition: background 0.15s, color 0.15s;
+        }
+        .btn:hover { background: var(--accent-blue); color: var(--bg-primary); }
+        .btn-start    { background: rgba(122, 162, 247, 0.18); color: var(--accent-blue); }
+        .btn-start:hover    { background: var(--accent-blue); color: var(--bg-primary); }
+        .btn-complete { background: rgba(158, 206, 106, 0.18); color: var(--accent-green); }
+        .btn-complete:hover { background: var(--accent-green); color: var(--bg-primary); }
+        .btn-block    { background: rgba(247, 118, 142, 0.18); color: var(--accent-red); }
+        .btn-block:hover    { background: var(--accent-red); color: var(--bg-primary); }
+        .btn-unblock  { background: rgba(224, 175, 104, 0.18); color: var(--accent-yellow); }
+        .btn-unblock:hover  { background: var(--accent-yellow); color: var(--bg-primary); }
+
         .error {
             background: rgba(247, 118, 142, 0.1);
             border: 1px solid var(--accent-red);
@@ -158,7 +182,9 @@
         </div>
 
         <div class="board">
+            {{$actions := .ActionsEnabled}}
             {{range .Board.Columns}}
+            {{$colStatus := .Status}}
             <section class="column col-{{.Status}}">
                 <header class="column-header">
                     <span class="column-title">{{.Name}}</span>
@@ -174,6 +200,18 @@
                             {{if .Owner}}<span class="card-owner">@{{.Owner}}</span>{{end}}
                             {{if .Task.DependsOn}}<span class="card-deps">⛓ {{len .Task.DependsOn}} dep{{if ne (len .Task.DependsOn) 1}}s{{end}}</span>{{end}}
                         </div>
+                        {{if $actions}}
+                        <div class="card-actions">
+                            {{if eq $colStatus "ready"}}
+                                <form method="POST" action="/actions/task/start"><input type="hidden" name="id" value="{{.Task.ID}}"><button class="btn btn-start" type="submit" title="Start this task">▶ Start</button></form>
+                            {{else if eq $colStatus "in_progress"}}
+                                <form method="POST" action="/actions/task/complete"><input type="hidden" name="id" value="{{.Task.ID}}"><button class="btn btn-complete" type="submit" title="Mark as done">✓ Complete</button></form>
+                                <form method="POST" action="/actions/task/block"><input type="hidden" name="id" value="{{.Task.ID}}"><button class="btn btn-block" type="submit" title="Mark blocked">⊘ Block</button></form>
+                            {{else if eq $colStatus "blocked"}}
+                                <form method="POST" action="/actions/task/unblock"><input type="hidden" name="id" value="{{.Task.ID}}"><button class="btn btn-unblock" type="submit" title="Resume work">↺ Unblock</button></form>
+                            {{end}}
+                        </div>
+                        {{end}}
                     </article>
                     {{end}}
                 {{else}}


### PR DESCRIPTION
## Summary

Cards on the \`/kanban\` board now have contextual action buttons that drive task state transitions through the existing \`TaskService\`:

| Column | Buttons |
|---|---|
| Ready | **Start** |
| In Progress | **Complete** / **Block** |
| Blocked | **Unblock** |

Plain HTML forms; no JavaScript required. After mutation, the user is redirected back to the referring page so the board refreshes with the new state.

Wired automatically by \`roady dashboard serve\`. Custom servers stay read-only unless they call \`Server.EnableTaskActions\`.

## New endpoints

\`\`\`
POST /actions/task/start     (form: id, optional owner)
POST /actions/task/complete  (form: id, optional evidence)
POST /actions/task/block     (form: id, optional reason)
POST /actions/task/unblock   (form: id)
\`\`\`

All return 303 See Other → Referer (defaulting to /kanban).

## Try it

\`\`\`bash
roady dashboard serve --port 3000
open http://localhost:3000/kanban
\`\`\`

Click **▶ Start** on a Ready card, watch it slide to In Progress on the next refresh.

## Test plan

- [x] 12 new unit tests in \`actions_test.go\` (happy path × 4, default owner, missing id, service error, redirect fallback, disabled actions × 4)
- [x] Full \`go test ./...\` green (43 packages, 0 FAILs)
- [x] \`golangci-lint run --new-from-rev=origin/main ./...\` clean

## Out of scope (follow-up)

- Drag-and-drop between columns
- Cross-project Kanban actions (\`/org/kanban\` cards stay read-only because routing needs to know which project's repo to mutate)
- Owner / evidence / reason prompts (today defaults: \`owner=dashboard\`, \`evidence=\"completed via dashboard\"\`, \`reason=\"blocked via dashboard\"\`)
- CSRF token — relying on same-origin browser policy for now