### PR TITLE
feat(dashboard): reopen + SSE live updates + cross-project DnD + auth (v0.12.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — Reopen action + DnD transition
+
+- New `TaskService.ReopenTask` + `POST /actions/task/reopen` move a Done or Verified task back to Pending.
+- Done cards on `/kanban` get a **↺ Reopen** button.
+- DnD adds Done → Backlog and Done → Ready transitions (both call reopen).
+
+### Added — Live updates over Server-Sent Events
+
+- New `GET /events` SSE stream emits a `task-changed` event after every successful task transition. The board reloads within ~200 ms of the change instead of waiting on the meta-refresh.
+- Live indicator in the header reflects connection state.
+- Meta-refresh kept as fallback (now 60 s) for browsers without `EventSource`.
+- 25 s heartbeat keeps the stream alive through proxies (Cloudflare, nginx).
+
+### Added — Cross-project Kanban actions (DnD on `/org/kanban`)
+
+- Cards on `/org/kanban` are now draggable. Drops route the mutation to the right sub-project's `TaskService` via the new `OrgTaskActions` resolver.
+- Action endpoints accept optional `project_path` and `project` form fields; absent → defaults to the server-default `TaskActions`, present → routes through `OrgTaskActions.ResolveTaskActions`.
+- Wired automatically by `roady dashboard serve`.
+
+### Added — Dashboard auth token
+
+- New `--auth-token <value>` flag on `roady dashboard serve|open` (env: `ROADY_DASHBOARD_TOKEN`) protects every dashboard request with a shared bearer token.
+- Token accepted three ways: `Authorization: Bearer <t>`, `Cookie: roady_token=<t>`, or `?token=<t>` (one-time handshake: sets the cookie, redirects to strip the secret from the URL bar).
+- Constant-time comparison; secure cookie on TLS / X-Forwarded-Proto.
+- Empty token = public (backward-compatible).
+
 ## [0.11.3] - 2026-05-16
 
 ### Added — Drag-and-drop on the Kanban board

--- a/internal/infrastructure/cli/dashboard.go
+++ b/internal/infrastructure/cli/dashboard.go
@@ -41,7 +41,19 @@ Use 'roady dashboard serve' for the web-based dashboard.`,
 	},
 }
 
-var dashboardPort int
+var (
+	dashboardPort      int
+	dashboardAuthToken string
+)
+
+// resolveDashboardToken picks the auth token from the --auth-token flag,
+// falling back to the ROADY_DASHBOARD_TOKEN env var. Empty = public.
+func resolveDashboardToken() string {
+	if dashboardAuthToken != "" {
+		return dashboardAuthToken
+	}
+	return os.Getenv("ROADY_DASHBOARD_TOKEN")
+}
 
 var dashboardServeCmd = &cobra.Command{
 	Use:   "serve",
@@ -75,10 +87,18 @@ Access the dashboard in your browser at the displayed URL.`,
 
 		// Wire cross-project Kanban over the workspace root so /org/kanban surfaces
 		// every project (root + sub-projects under .roady/projects/<name>/).
-		server.EnableOrgKanban(application.NewOrgService(services.Workspace.Repo.Root()), nil)
-		// Wire task-action buttons (Start / Complete / Block / Unblock) on the
-		// per-project Kanban board.
+		root := services.Workspace.Repo.Root()
+		server.EnableOrgKanban(application.NewOrgService(root), nil)
+		// Wire task-action buttons (Start / Complete / Block / Unblock / Reopen)
+		// on the per-project Kanban board.
 		server.EnableTaskActions(services.Task)
+		// Wire cross-project action routing so /org/kanban DnD targets the
+		// right sub-project's TaskService.
+		server.EnableOrgTaskActions(newOrgTaskActionsResolver(root))
+		// Optional auth token gate (--auth-token flag or ROADY_DASHBOARD_TOKEN env).
+		if tok := resolveDashboardToken(); tok != "" {
+			server.EnableAuthToken(tok)
+		}
 
 		// Handle graceful shutdown
 		stop := make(chan os.Signal, 1)
@@ -123,10 +143,18 @@ var dashboardOpenCmd = &cobra.Command{
 
 		// Wire cross-project Kanban over the workspace root so /org/kanban surfaces
 		// every project (root + sub-projects under .roady/projects/<name>/).
-		server.EnableOrgKanban(application.NewOrgService(services.Workspace.Repo.Root()), nil)
-		// Wire task-action buttons (Start / Complete / Block / Unblock) on the
-		// per-project Kanban board.
+		root := services.Workspace.Repo.Root()
+		server.EnableOrgKanban(application.NewOrgService(root), nil)
+		// Wire task-action buttons (Start / Complete / Block / Unblock / Reopen)
+		// on the per-project Kanban board.
 		server.EnableTaskActions(services.Task)
+		// Wire cross-project action routing so /org/kanban DnD targets the
+		// right sub-project's TaskService.
+		server.EnableOrgTaskActions(newOrgTaskActionsResolver(root))
+		// Optional auth token gate (--auth-token flag or ROADY_DASHBOARD_TOKEN env).
+		if tok := resolveDashboardToken(); tok != "" {
+			server.EnableAuthToken(tok)
+		}
 
 		// Handle graceful shutdown
 		stop := make(chan os.Signal, 1)
@@ -173,6 +201,10 @@ func init() {
 
 	dashboardServeCmd.Flags().IntVarP(&dashboardPort, "port", "p", 3000, "Port to listen on")
 	dashboardOpenCmd.Flags().IntVarP(&dashboardPort, "port", "p", 3000, "Port to listen on")
+
+	const tokHelp = "Shared bearer token required on every request (env: ROADY_DASHBOARD_TOKEN). Empty = public."
+	dashboardServeCmd.Flags().StringVar(&dashboardAuthToken, "auth-token", "", tokHelp)
+	dashboardOpenCmd.Flags().StringVar(&dashboardAuthToken, "auth-token", "", tokHelp)
 }
 
 // dashboardDataProvider implements dashboard.DataProvider

--- a/internal/infrastructure/cli/dashboard_org_actions.go
+++ b/internal/infrastructure/cli/dashboard_org_actions.go
@@ -1,0 +1,31 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/felixgeelhaar/roady/internal/infrastructure/wiring"
+	"github.com/felixgeelhaar/roady/pkg/infrastructure/dashboard"
+)
+
+// orgTaskActionsResolver implements dashboard.OrgTaskActions by building
+// AppServices for the requested (projectPath, project) pair on demand. The
+// underlying wiring.BuildAppServicesForProject is cached internally.
+type orgTaskActionsResolver struct {
+	defaultPath string
+}
+
+func newOrgTaskActionsResolver(defaultPath string) *orgTaskActionsResolver {
+	return &orgTaskActionsResolver{defaultPath: defaultPath}
+}
+
+func (r *orgTaskActionsResolver) ResolveTaskActions(projectPath, project string) (dashboard.TaskActions, error) {
+	root := projectPath
+	if root == "" {
+		root = r.defaultPath
+	}
+	svc, err := wiring.BuildAppServicesForProject(root, project)
+	if err != nil && svc == nil {
+		return nil, fmt.Errorf("build services for %s / %s: %w", root, project, err)
+	}
+	return svc.Task, nil
+}

--- a/pkg/application/task_service.go
+++ b/pkg/application/task_service.go
@@ -298,6 +298,18 @@ func (s *TaskService) UnblockTask(ctx context.Context, taskID string) error {
 	return nil
 }
 
+// ReopenTask transitions a Done or Verified task back to Pending so it can
+// be re-planned and started again.
+func (s *TaskService) ReopenTask(ctx context.Context, taskID string) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := s.coordinator.ReopenTask(ctx, taskID); err != nil {
+		return s.mapCoordinatorError(err, "reopen")
+	}
+	return nil
+}
+
 // VerifyTask marks a completed task as verified.
 func (s *TaskService) VerifyTask(ctx context.Context, taskID, verifier string) error {
 	if ctx == nil {

--- a/pkg/domain/project/coordinator.go
+++ b/pkg/domain/project/coordinator.go
@@ -318,6 +318,45 @@ func (c *Coordinator) UnblockTask(ctx context.Context, taskID string) error {
 	return nil
 }
 
+// ReopenTask transitions a Done or Verified task back to Pending so it can
+// be picked up and started again. Useful when a completion was premature or
+// new evidence shows the task is not actually finished.
+func (c *Coordinator) ReopenTask(ctx context.Context, taskID string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	state, err := c.stateRepo.Load(ctx)
+	if err != nil {
+		return err
+	}
+	if state == nil {
+		return ErrNoState
+	}
+
+	currentStatus := state.GetTaskStatus(taskID)
+	if !currentStatus.CanTransitionWith("reopen") {
+		return &TransitionError{
+			TaskID:     taskID,
+			FromStatus: string(currentStatus),
+			ToStatus:   string(planning.StatusPending),
+			Event:      "reopen",
+		}
+	}
+
+	state.SetTaskStatus(taskID, planning.StatusPending)
+	if err := c.stateRepo.Save(ctx, state); err != nil {
+		return err
+	}
+
+	// Fire-and-forget; reuse the unblock event since both land in Pending and
+	// signal "this task is back in flight".
+	if c.publisher != nil {
+		_ = c.publisher.PublishTaskUnblocked(ctx, taskID)
+	}
+
+	return nil
+}
+
 // VerifyTask marks a completed task as verified.
 func (c *Coordinator) VerifyTask(ctx context.Context, taskID, verifier string) error {
 	c.mu.Lock()

--- a/pkg/infrastructure/dashboard/actions.go
+++ b/pkg/infrastructure/dashboard/actions.go
@@ -14,12 +14,38 @@ type TaskActions interface {
 	CompleteTask(ctx context.Context, taskID, evidence string) ([]string, error)
 	BlockTask(ctx context.Context, taskID, reason string) error
 	UnblockTask(ctx context.Context, taskID string) error
+	ReopenTask(ctx context.Context, taskID string) error
 }
 
 // EnableTaskActions wires POST handlers that mutate task state from the
 // dashboard (Kanban card buttons). Pass nil to keep the board read-only.
 func (s *Server) EnableTaskActions(svc TaskActions) {
 	s.taskActions = svc
+}
+
+// OrgTaskActions resolves a TaskActions for a (project_path, project) pair so
+// the dashboard can mutate state on sub-projects from /org/kanban.
+type OrgTaskActions interface {
+	ResolveTaskActions(projectPath, project string) (TaskActions, error)
+}
+
+// EnableOrgTaskActions wires cross-project action endpoints. Pass nil to keep
+// /org/kanban read-only.
+func (s *Server) EnableOrgTaskActions(resolver OrgTaskActions) {
+	s.orgTaskActions = resolver
+}
+
+// pickActions returns the TaskActions to use for the current request. If the
+// request carries a project_path or project form field and an OrgTaskActions
+// resolver is wired, the per-project actions are returned. Falls back to
+// s.taskActions otherwise.
+func (s *Server) pickActions(r *http.Request) (TaskActions, error) {
+	path := r.PostForm.Get("project_path")
+	proj := r.PostForm.Get("project")
+	if (path != "" || proj != "") && s.orgTaskActions != nil {
+		return s.orgTaskActions.ResolveTaskActions(path, proj)
+	}
+	return s.taskActions, nil
 }
 
 // redirectAfterAction sends the user back to the page they came from
@@ -33,12 +59,17 @@ func redirectAfterAction(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleTaskStart(w http.ResponseWriter, r *http.Request) {
-	if s.taskActions == nil {
-		http.Error(w, "task actions not enabled", http.StatusServiceUnavailable)
-		return
-	}
 	if err := r.ParseForm(); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	actions, err := s.pickActions(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if actions == nil {
+		http.Error(w, "task actions not enabled", http.StatusServiceUnavailable)
 		return
 	}
 	id := r.PostForm.Get("id")
@@ -47,20 +78,26 @@ func (s *Server) handleTaskStart(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	owner := strDefault(r.PostForm.Get("owner"), "dashboard")
-	if err := s.taskActions.StartTask(r.Context(), id, owner, ""); err != nil {
+	if err := actions.StartTask(r.Context(), id, owner, ""); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
+	s.broadcastChange()
 	redirectAfterAction(w, r)
 }
 
 func (s *Server) handleTaskComplete(w http.ResponseWriter, r *http.Request) {
-	if s.taskActions == nil {
-		http.Error(w, "task actions not enabled", http.StatusServiceUnavailable)
-		return
-	}
 	if err := r.ParseForm(); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	actions, err := s.pickActions(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if actions == nil {
+		http.Error(w, "task actions not enabled", http.StatusServiceUnavailable)
 		return
 	}
 	id := r.PostForm.Get("id")
@@ -69,20 +106,26 @@ func (s *Server) handleTaskComplete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	evidence := strDefault(r.PostForm.Get("evidence"), "completed via dashboard")
-	if _, err := s.taskActions.CompleteTask(r.Context(), id, evidence); err != nil {
+	if _, err := actions.CompleteTask(r.Context(), id, evidence); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
+	s.broadcastChange()
 	redirectAfterAction(w, r)
 }
 
 func (s *Server) handleTaskBlock(w http.ResponseWriter, r *http.Request) {
-	if s.taskActions == nil {
-		http.Error(w, "task actions not enabled", http.StatusServiceUnavailable)
-		return
-	}
 	if err := r.ParseForm(); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	actions, err := s.pickActions(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if actions == nil {
+		http.Error(w, "task actions not enabled", http.StatusServiceUnavailable)
 		return
 	}
 	id := r.PostForm.Get("id")
@@ -91,20 +134,26 @@ func (s *Server) handleTaskBlock(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	reason := strDefault(r.PostForm.Get("reason"), "blocked via dashboard")
-	if err := s.taskActions.BlockTask(r.Context(), id, reason); err != nil {
+	if err := actions.BlockTask(r.Context(), id, reason); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
+	s.broadcastChange()
 	redirectAfterAction(w, r)
 }
 
 func (s *Server) handleTaskUnblock(w http.ResponseWriter, r *http.Request) {
-	if s.taskActions == nil {
-		http.Error(w, "task actions not enabled", http.StatusServiceUnavailable)
-		return
-	}
 	if err := r.ParseForm(); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	actions, err := s.pickActions(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if actions == nil {
+		http.Error(w, "task actions not enabled", http.StatusServiceUnavailable)
 		return
 	}
 	id := r.PostForm.Get("id")
@@ -112,10 +161,38 @@ func (s *Server) handleTaskUnblock(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "missing task id", http.StatusBadRequest)
 		return
 	}
-	if err := s.taskActions.UnblockTask(r.Context(), id); err != nil {
+	if err := actions.UnblockTask(r.Context(), id); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
+	s.broadcastChange()
+	redirectAfterAction(w, r)
+}
+
+func (s *Server) handleTaskReopen(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	actions, err := s.pickActions(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if actions == nil {
+		http.Error(w, "task actions not enabled", http.StatusServiceUnavailable)
+		return
+	}
+	id := r.PostForm.Get("id")
+	if id == "" {
+		http.Error(w, "missing task id", http.StatusBadRequest)
+		return
+	}
+	if err := actions.ReopenTask(r.Context(), id); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	s.broadcastChange()
 	redirectAfterAction(w, r)
 }
 

--- a/pkg/infrastructure/dashboard/actions_test.go
+++ b/pkg/infrastructure/dashboard/actions_test.go
@@ -18,17 +18,20 @@ type fakeTaskActions struct {
 	completeCalled *completeArgs
 	blockCalled    *blockArgs
 	unblockCalled  *unblockArgs
+	reopenCalled   *reopenArgs
 
 	startErr    error
 	completeErr error
 	blockErr    error
 	unblockErr  error
+	reopenErr   error
 }
 
 type startArgs struct{ id, owner, rateID string }
 type completeArgs struct{ id, evidence string }
 type blockArgs struct{ id, reason string }
 type unblockArgs struct{ id string }
+type reopenArgs struct{ id string }
 
 func (f *fakeTaskActions) StartTask(ctx context.Context, id, owner, rateID string) error {
 	f.startCalled = &startArgs{id, owner, rateID}
@@ -45,6 +48,10 @@ func (f *fakeTaskActions) BlockTask(ctx context.Context, id, reason string) erro
 func (f *fakeTaskActions) UnblockTask(ctx context.Context, id string) error {
 	f.unblockCalled = &unblockArgs{id}
 	return f.unblockErr
+}
+func (f *fakeTaskActions) ReopenTask(ctx context.Context, id string) error {
+	f.reopenCalled = &reopenArgs{id}
+	return f.reopenErr
 }
 
 func newActionsServer(t *testing.T, actions TaskActions) *Server {

--- a/pkg/infrastructure/dashboard/auth.go
+++ b/pkg/infrastructure/dashboard/auth.go
@@ -1,0 +1,79 @@
+package dashboard
+
+import (
+	"crypto/subtle"
+	"net/http"
+	"strings"
+)
+
+// EnableAuthToken protects every dashboard request with a shared token. Pass
+// an empty string to leave the server public. The token is accepted on three
+// surfaces:
+//   - Authorization: Bearer <token>
+//   - Cookie:        roady_token=<token>
+//   - Query param:   ?token=<token>  (one-time, sets the cookie + redirects)
+//
+// Token comparison is constant-time.
+func (s *Server) EnableAuthToken(token string) {
+	s.authToken = token
+}
+
+const authCookieName = "roady_token"
+
+// authMiddleware enforces the shared token. The handler short-circuits with
+// 401 unless one of the accepted credentials matches. A successful
+// ?token=<v> handshake sets the cookie + redirects to strip the secret from
+// the URL bar.
+func authMiddleware(token string, next http.Handler) http.Handler {
+	tokenBytes := []byte(token)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// 1. Query-param handshake (one-time): set cookie + redirect without param.
+		if q := r.URL.Query().Get("token"); q != "" {
+			if constantTimeEqual(q, token, tokenBytes) {
+				http.SetCookie(w, &http.Cookie{
+					Name:     authCookieName,
+					Value:    q,
+					Path:     "/",
+					HttpOnly: true,
+					Secure:   r.TLS != nil || strings.EqualFold(r.Header.Get("X-Forwarded-Proto"), "https"),
+					SameSite: http.SameSiteLaxMode,
+					MaxAge:   24 * 60 * 60 * 30, // 30 days
+				})
+				redirect := *r.URL
+				q := redirect.Query()
+				q.Del("token")
+				redirect.RawQuery = q.Encode()
+				http.Redirect(w, r, redirect.String(), http.StatusSeeOther)
+				return
+			}
+			// fall through; bad token in query is treated as unauthenticated
+		}
+
+		// 2. Cookie.
+		if c, err := r.Cookie(authCookieName); err == nil {
+			if constantTimeEqual(c.Value, token, tokenBytes) {
+				next.ServeHTTP(w, r)
+				return
+			}
+		}
+
+		// 3. Bearer.
+		if h := r.Header.Get("Authorization"); strings.HasPrefix(h, "Bearer ") {
+			if constantTimeEqual(strings.TrimPrefix(h, "Bearer "), token, tokenBytes) {
+				next.ServeHTTP(w, r)
+				return
+			}
+		}
+
+		w.Header().Set("WWW-Authenticate", `Bearer realm="roady-dashboard"`)
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+	})
+}
+
+func constantTimeEqual(got, _ string, want []byte) bool {
+	gotB := []byte(got)
+	if len(gotB) != len(want) {
+		return false
+	}
+	return subtle.ConstantTimeCompare(gotB, want) == 1
+}

--- a/pkg/infrastructure/dashboard/kanban_test.go
+++ b/pkg/infrastructure/dashboard/kanban_test.go
@@ -152,7 +152,7 @@ func TestKanbanHTMLHandler_RendersAllColumns(t *testing.T) {
 		t.Fatalf("status = %d, want 200", rec.Code)
 	}
 	body := rec.Body.String()
-	for _, want := range []string{"Backlog", "Ready", "In Progress", "Blocked", "Done", "auto-refresh 30s"} {
+	for _, want := range []string{"Backlog", "Ready", "In Progress", "Blocked", "Done", `id="live-state"`} {
 		if !strings.Contains(body, want) {
 			t.Errorf("body missing %q", want)
 		}

--- a/pkg/infrastructure/dashboard/org_kanban.go
+++ b/pkg/infrastructure/dashboard/org_kanban.go
@@ -87,10 +87,13 @@ func buildOrgKanbanBoard(prov OrgKanbanProvider, open repoOpener) OrgKanbanBoard
 
 		sub := buildKanbanBoard(plan, state)
 		// Merge sub-board tasks into the org columns, tagging each card with
-		// its project so consumers can disambiguate.
+		// its project so consumers can disambiguate and so action endpoints
+		// can route the mutation back to the right sub-project.
 		for _, sc := range sub.Columns {
 			for _, tv := range sc.Tasks {
 				tv.ProjectLabel = label
+				tv.ProjectPath = p.Path
+				tv.ProjectName = p.SubProject
 				cols[sc.Status].Tasks = append(cols[sc.Status].Tasks, tv)
 			}
 		}

--- a/pkg/infrastructure/dashboard/server.go
+++ b/pkg/infrastructure/dashboard/server.go
@@ -37,7 +37,15 @@ type Server struct {
 
 	// Optional task-action wiring. When set, POST /actions/task/* routes are
 	// registered and the Kanban board renders action buttons. See EnableTaskActions.
-	taskActions TaskActions
+	taskActions    TaskActions
+	orgTaskActions OrgTaskActions
+
+	// Optional SSE hub for live updates. Created on first /events subscription.
+	sse *sseHub
+
+	// Optional bearer-token gate for every request. When empty, the server is
+	// public. See EnableAuthToken.
+	authToken string
 }
 
 // NewServer creates a new dashboard server.
@@ -82,13 +90,25 @@ func (s *Server) Start() error {
 		mux.HandleFunc("POST /actions/task/complete", s.handleTaskComplete)
 		mux.HandleFunc("POST /actions/task/block", s.handleTaskBlock)
 		mux.HandleFunc("POST /actions/task/unblock", s.handleTaskUnblock)
+		mux.HandleFunc("POST /actions/task/reopen", s.handleTaskReopen)
+	}
+
+	// SSE live-update stream. Always registered; clients reconnect on disconnect.
+	if s.sse == nil {
+		s.sse = newSSEHub()
+	}
+	mux.HandleFunc("GET /events", s.handleEvents)
+
+	handler := http.Handler(mux)
+	if s.authToken != "" {
+		handler = authMiddleware(s.authToken, handler)
 	}
 
 	s.server = &http.Server{
 		Addr:         s.addr,
-		Handler:      mux,
+		Handler:      handler,
 		ReadTimeout:  15 * time.Second,
-		WriteTimeout: 15 * time.Second,
+		WriteTimeout: 0, // SSE needs no write timeout
 	}
 
 	log.Printf("Dashboard server starting on %s", s.addr)
@@ -120,6 +140,8 @@ type TaskView struct {
 	Owner        string
 	HasLinks     bool
 	ProjectLabel string // set on cross-project Kanban cards; empty for per-project views
+	ProjectPath  string // workspace root, set on org-kanban cards so actions can route to it
+	ProjectName  string // sub-project name (empty = root project), set on org-kanban cards
 }
 
 // DashboardStats holds summary statistics.

--- a/pkg/infrastructure/dashboard/sse.go
+++ b/pkg/infrastructure/dashboard/sse.go
@@ -1,0 +1,109 @@
+package dashboard
+
+import (
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// sseHub fans state-change notifications out to every connected client.
+// Each /events subscriber owns a buffered channel; broadcastChange drops the
+// message rather than blocking when a subscriber is slow — the client will
+// catch up on the next event or reload.
+type sseHub struct {
+	mu      sync.RWMutex
+	clients map[chan string]struct{}
+}
+
+func newSSEHub() *sseHub {
+	return &sseHub{clients: map[chan string]struct{}{}}
+}
+
+func (h *sseHub) subscribe() chan string {
+	ch := make(chan string, 4)
+	h.mu.Lock()
+	h.clients[ch] = struct{}{}
+	h.mu.Unlock()
+	return ch
+}
+
+func (h *sseHub) unsubscribe(ch chan string) {
+	h.mu.Lock()
+	if _, ok := h.clients[ch]; ok {
+		delete(h.clients, ch)
+		close(ch)
+	}
+	h.mu.Unlock()
+}
+
+func (h *sseHub) broadcast(event string) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	for ch := range h.clients {
+		select {
+		case ch <- event:
+		default:
+			// drop on slow client; they'll resync on next event or reload
+		}
+	}
+}
+
+// broadcastChange notifies all /events subscribers that the board state has
+// mutated. Called from every action handler after a successful transition.
+func (s *Server) broadcastChange() {
+	if s.sse != nil {
+		s.sse.broadcast("task-changed")
+	}
+}
+
+// handleEvents serves the SSE stream. The client opens an EventSource on
+// /events and receives `event: task-changed\ndata: <ts>\n\n` whenever the
+// server mutates state. A 25s heartbeat keeps proxies from dropping the
+// connection.
+func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming not supported", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache, no-transform")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no") // nginx + cloudflare hint
+
+	if s.sse == nil {
+		s.sse = newSSEHub()
+	}
+	ch := s.sse.subscribe()
+	defer s.sse.unsubscribe(ch)
+
+	// Initial comment so the client treats the stream as open immediately.
+	if _, err := fmt.Fprintf(w, ": connected at %s\n\n", time.Now().UTC().Format(time.RFC3339)); err != nil {
+		return
+	}
+	flusher.Flush()
+
+	heartbeat := time.NewTicker(25 * time.Second)
+	defer heartbeat.Stop()
+
+	for {
+		select {
+		case <-r.Context().Done():
+			return
+		case <-heartbeat.C:
+			if _, err := fmt.Fprintf(w, ": ping %d\n\n", time.Now().Unix()); err != nil {
+				return
+			}
+			flusher.Flush()
+		case ev, ok := <-ch:
+			if !ok {
+				return
+			}
+			if _, err := fmt.Fprintf(w, "event: %s\ndata: %d\n\n", ev, time.Now().UnixNano()); err != nil {
+				return
+			}
+			flusher.Flush()
+		}
+	}
+}

--- a/pkg/infrastructure/dashboard/templates/kanban.html
+++ b/pkg/infrastructure/dashboard/templates/kanban.html
@@ -4,7 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Roady - Kanban</title>
-    <meta http-equiv="refresh" content="30">
+    <!-- Fallback poll; superseded by the SSE live-update stream when available. -->
+    <meta http-equiv="refresh" content="60">
     <style>
         :root {
             --bg-primary: #1a1b26;
@@ -196,7 +197,7 @@
             <span class="kanban-meta">
                 {{.Board.TotalTasks}} task{{if ne .Board.TotalTasks 1}}s{{end}}
                 · updated {{.Board.UpdatedAt.Format "15:04:05"}}
-                · auto-refresh 30s
+                · <span id="live-state" title="Live updates via Server-Sent Events">live</span>
                 · <a href="/api/kanban" style="color: var(--text-muted)">JSON</a>
                 {{if .ActionsEnabled}}<span class="dnd-hint">· drag cards between columns</span>{{end}}
             </span>
@@ -230,6 +231,8 @@
                                 <form method="POST" action="/actions/task/block"><input type="hidden" name="id" value="{{.Task.ID}}"><button class="btn btn-block" type="submit" title="Mark blocked">⊘ Block</button></form>
                             {{else if eq $colStatus "blocked"}}
                                 <form method="POST" action="/actions/task/unblock"><input type="hidden" name="id" value="{{.Task.ID}}"><button class="btn btn-unblock" type="submit" title="Resume work">↺ Unblock</button></form>
+                            {{else if eq $colStatus "done"}}
+                                <form method="POST" action="/actions/task/reopen"><input type="hidden" name="id" value="{{.Task.ID}}"><button class="btn btn-unblock" type="submit" title="Reopen (back to backlog)">↺ Reopen</button></form>
                             {{end}}
                         </div>
                         {{end}}
@@ -256,6 +259,8 @@
             "in_progress,done":       "/actions/task/complete",
             "in_progress,blocked":    "/actions/task/block",
             "blocked,in_progress":    "/actions/task/unblock",
+            "done,backlog":           "/actions/task/reopen",
+            "done,ready":             "/actions/task/reopen",
         };
 
         function endpointFor(src, dst) {
@@ -322,5 +327,27 @@
     })();
     </script>
     {{end}}
+
+    <script>
+    // SSE live-update: subscribe to /events; on `task-changed`, reload board.
+    (function () {
+        if (!('EventSource' in window)) return;
+        const indicator = document.getElementById('live-state');
+        function setIndicator(text, color) {
+            if (!indicator) return;
+            indicator.textContent = text;
+            indicator.style.color = color;
+        }
+        try {
+            const es = new EventSource('/events');
+            es.onopen = function () { setIndicator('live', 'var(--accent-green)'); };
+            es.onerror = function () { setIndicator('reconnecting…', 'var(--accent-yellow)'); };
+            es.addEventListener('task-changed', function () {
+                // Tiny delay so multiple in-flight POSTs collapse to one reload.
+                setTimeout(function () { window.location.reload(); }, 200);
+            });
+        } catch (e) { /* swallow; meta-refresh fallback still works */ }
+    })();
+    </script>
 </body>
 </html>

--- a/pkg/infrastructure/dashboard/templates/org_kanban.html
+++ b/pkg/infrastructure/dashboard/templates/org_kanban.html
@@ -115,7 +115,8 @@
 
     <div class="board">
         {{range .Board.Columns}}
-        <section class="column col-{{.Status}}">
+        {{$colStatus := .Status}}
+        <section class="column col-{{.Status}}" data-status="{{.Status}}">
             <header class="column-header">
                 <span class="column-title">{{.Name}}</span>
                 <span class="column-count">{{.Count}}</span>
@@ -123,7 +124,11 @@
 
             {{if .Tasks}}
                 {{range .Tasks}}
-                <article class="card">
+                <article class="card" draggable="true"
+                         data-task-id="{{.Task.ID}}"
+                         data-source="{{$colStatus}}"
+                         data-project-path="{{.ProjectPath}}"
+                         data-project-name="{{.ProjectName}}">
                     {{if .ProjectLabel}}<div class="card-project">{{.ProjectLabel}}</div>{{end}}
                     <div class="card-title">{{.Task.Title}}</div>
                     <div class="card-meta">
@@ -140,5 +145,92 @@
     </div>
 
     <footer>Roady Org Kanban · live cross-project view · <a href="/kanban" style="color: var(--text-muted)">single project</a></footer>
+
+    <style>
+        .card[draggable="true"] { cursor: grab; }
+        .card.dragging          { opacity: 0.4; cursor: grabbing; }
+        .column.drop-allow      { outline: 2px dashed var(--accent-green); outline-offset: -4px; background: rgba(158, 206, 106, 0.06); }
+        .column.drop-deny       { outline: 2px dashed var(--accent-red);   outline-offset: -4px; background: rgba(247, 118, 142, 0.06); cursor: not-allowed; }
+    </style>
+
+    <script>
+    (function () {
+        const TRANSITIONS = {
+            "ready,in_progress":      "/actions/task/start",
+            "in_progress,done":       "/actions/task/complete",
+            "in_progress,blocked":    "/actions/task/block",
+            "blocked,in_progress":    "/actions/task/unblock",
+            "done,backlog":           "/actions/task/reopen",
+            "done,ready":             "/actions/task/reopen",
+        };
+        function endpointFor(s, d) { return TRANSITIONS[s + "," + d] || null; }
+
+        function postAction(endpoint, taskId, projectPath, projectName) {
+            const body = new URLSearchParams({ id: taskId });
+            if (projectPath) body.set("project_path", projectPath);
+            if (projectName) body.set("project", projectName);
+            return fetch(endpoint, {
+                method: "POST",
+                headers: { "Content-Type": "application/x-www-form-urlencoded" },
+                body: body.toString(),
+                redirect: "manual",
+            }).then(function () { window.location.reload(); });
+        }
+
+        document.querySelectorAll('.card[draggable="true"]').forEach(function (card) {
+            card.addEventListener('dragstart', function (e) {
+                card.classList.add('dragging');
+                e.dataTransfer.effectAllowed = 'move';
+                e.dataTransfer.setData('text/plain', card.dataset.taskId);
+                e.dataTransfer.setData('application/x-source', card.dataset.source);
+                e.dataTransfer.setData('application/x-project-path', card.dataset.projectPath || '');
+                e.dataTransfer.setData('application/x-project-name', card.dataset.projectName || '');
+            });
+            card.addEventListener('dragend', function () { card.classList.remove('dragging'); });
+        });
+
+        document.querySelectorAll('.column[data-status]').forEach(function (col) {
+            col.addEventListener('dragover', function (e) {
+                e.preventDefault();
+                const dragging = document.querySelector('.card.dragging');
+                if (!dragging) return;
+                const src = dragging.dataset.source;
+                const dst = col.dataset.status;
+                if (src === dst) return;
+                if (endpointFor(src, dst)) {
+                    e.dataTransfer.dropEffect = 'move';
+                    col.classList.add('drop-allow');
+                } else {
+                    e.dataTransfer.dropEffect = 'none';
+                    col.classList.add('drop-deny');
+                }
+            });
+            col.addEventListener('dragleave', function () { col.classList.remove('drop-allow', 'drop-deny'); });
+            col.addEventListener('drop', function (e) {
+                e.preventDefault();
+                col.classList.remove('drop-allow', 'drop-deny');
+                const taskId = e.dataTransfer.getData('text/plain');
+                const src    = e.dataTransfer.getData('application/x-source');
+                const dst    = col.dataset.status;
+                const projectPath = e.dataTransfer.getData('application/x-project-path');
+                const projectName = e.dataTransfer.getData('application/x-project-name');
+                if (!taskId || src === dst) return;
+                const endpoint = endpointFor(src, dst);
+                if (!endpoint) return;
+                postAction(endpoint, taskId, projectPath, projectName);
+            });
+        });
+
+        // SSE live updates (shared stream with /kanban).
+        if ('EventSource' in window) {
+            try {
+                const es = new EventSource('/events');
+                es.addEventListener('task-changed', function () {
+                    setTimeout(function () { window.location.reload(); }, 200);
+                });
+            } catch (e) {}
+        }
+    })();
+    </script>
 </body>
 </html>

--- a/pkg/infrastructure/dashboard/v012_test.go
+++ b/pkg/infrastructure/dashboard/v012_test.go
@@ -1,0 +1,294 @@
+package dashboard
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/felixgeelhaar/roady/pkg/domain/planning"
+)
+
+// --- Reopen handler ----------------------------------------------------------
+
+func TestHandleTaskReopen_HappyPath(t *testing.T) {
+	a := &fakeTaskActions{}
+	srv := newActionsServer(t, a)
+	rec := postForm(t, srv.handleTaskReopen, "/actions/task/reopen", url.Values{"id": {"r-1"}})
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want 303", rec.Code)
+	}
+	if a.reopenCalled == nil || a.reopenCalled.id != "r-1" {
+		t.Errorf("ReopenTask call = %+v, want {r-1}", a.reopenCalled)
+	}
+}
+
+func TestHandleTaskReopen_Disabled(t *testing.T) {
+	srv := newActionsServer(t, nil)
+	rec := postForm(t, srv.handleTaskReopen, "/actions/task/reopen", url.Values{"id": {"x"}})
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503", rec.Code)
+	}
+}
+
+// --- Org actions routing ----------------------------------------------------
+
+type stubOrgActions struct {
+	called  atomic.Int32
+	gotPath string
+	gotProj string
+	out     TaskActions
+	err     error
+}
+
+func (s *stubOrgActions) ResolveTaskActions(path, proj string) (TaskActions, error) {
+	s.called.Add(1)
+	s.gotPath = path
+	s.gotProj = proj
+	return s.out, s.err
+}
+
+func TestPickActions_FallsBackToDefault(t *testing.T) {
+	defaultActions := &fakeTaskActions{}
+	srv := newActionsServer(t, defaultActions)
+	srv.EnableOrgTaskActions(&stubOrgActions{out: &fakeTaskActions{}})
+
+	req := httptest.NewRequest(http.MethodPost, "/x", strings.NewReader("id=t"))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	_ = req.ParseForm()
+
+	got, err := srv.pickActions(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != TaskActions(defaultActions) {
+		t.Errorf("got != default; got=%T", got)
+	}
+}
+
+func TestPickActions_RoutesToOrgWhenProjectSet(t *testing.T) {
+	defaultActions := &fakeTaskActions{}
+	orgActions := &fakeTaskActions{}
+	stub := &stubOrgActions{out: orgActions}
+
+	srv := newActionsServer(t, defaultActions)
+	srv.EnableOrgTaskActions(stub)
+
+	req := httptest.NewRequest(http.MethodPost, "/x",
+		strings.NewReader("id=t&project_path=/repo&project=auth"))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	_ = req.ParseForm()
+
+	got, err := srv.pickActions(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != TaskActions(orgActions) {
+		t.Errorf("got != orgActions; got=%T", got)
+	}
+	if stub.called.Load() != 1 {
+		t.Errorf("resolver called %d times, want 1", stub.called.Load())
+	}
+	if stub.gotPath != "/repo" || stub.gotProj != "auth" {
+		t.Errorf("resolver got (%q, %q), want (/repo, auth)", stub.gotPath, stub.gotProj)
+	}
+}
+
+func TestPickActions_ResolverErrorBubbles(t *testing.T) {
+	srv := newActionsServer(t, nil)
+	srv.EnableOrgTaskActions(&stubOrgActions{err: errors.New("boom")})
+
+	req := httptest.NewRequest(http.MethodPost, "/x", strings.NewReader("project=auth"))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	_ = req.ParseForm()
+
+	if _, err := srv.pickActions(req); err == nil {
+		t.Error("expected error from resolver")
+	}
+}
+
+func TestHandleTaskStart_RoutedViaOrgResolver(t *testing.T) {
+	orgActions := &fakeTaskActions{}
+	stub := &stubOrgActions{out: orgActions}
+	srv := newActionsServer(t, &fakeTaskActions{})
+	srv.EnableOrgTaskActions(stub)
+
+	rec := postForm(t, srv.handleTaskStart, "/actions/task/start",
+		url.Values{"id": {"t-9"}, "project_path": {"/repo"}, "project": {"auth"}})
+
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	if orgActions.startCalled == nil || orgActions.startCalled.id != "t-9" {
+		t.Errorf("expected start on org-routed actions; got %+v", orgActions.startCalled)
+	}
+	if stub.called.Load() == 0 {
+		t.Error("resolver never called")
+	}
+}
+
+// --- Auth middleware --------------------------------------------------------
+
+func newAuthedServer(t *testing.T, token string) *Server {
+	t.Helper()
+	srv, err := NewServer(":0", &kanbanStubProvider{plan: &planning.Plan{}, state: &planning.ExecutionState{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv.EnableAuthToken(token)
+	return srv
+}
+
+func TestAuthMiddleware_NoTokenIsPublic(t *testing.T) {
+	srv := newAuthedServer(t, "")
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(200) }))
+	if srv.authToken != "" {
+		handler = authMiddleware(srv.authToken, handler)
+	}
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/x", nil))
+	if rec.Code != 200 {
+		t.Errorf("public path: got %d, want 200", rec.Code)
+	}
+}
+
+func TestAuthMiddleware_RejectsNoAuth(t *testing.T) {
+	h := authMiddleware("secret", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(200) }))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/x", nil))
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("got %d, want 401", rec.Code)
+	}
+	if rec.Header().Get("WWW-Authenticate") == "" {
+		t.Error("expected WWW-Authenticate header")
+	}
+}
+
+func TestAuthMiddleware_AcceptsBearer(t *testing.T) {
+	h := authMiddleware("secret", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(200) }))
+	req := httptest.NewRequest(http.MethodGet, "/x", nil)
+	req.Header.Set("Authorization", "Bearer secret")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != 200 {
+		t.Errorf("got %d, want 200", rec.Code)
+	}
+}
+
+func TestAuthMiddleware_AcceptsCookie(t *testing.T) {
+	h := authMiddleware("secret", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(200) }))
+	req := httptest.NewRequest(http.MethodGet, "/x", nil)
+	req.AddCookie(&http.Cookie{Name: authCookieName, Value: "secret"})
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != 200 {
+		t.Errorf("got %d, want 200", rec.Code)
+	}
+}
+
+func TestAuthMiddleware_QueryHandshakeSetsCookieAndRedirects(t *testing.T) {
+	h := authMiddleware("secret", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(200) }))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/kanban?token=secret&other=keep", nil))
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("got %d, want 303", rec.Code)
+	}
+	loc := rec.Header().Get("Location")
+	if loc == "" || strings.Contains(loc, "token=") {
+		t.Errorf("redirect should strip token; got %q", loc)
+	}
+	var found bool
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == authCookieName && c.Value == "secret" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected cookie to be set")
+	}
+}
+
+func TestAuthMiddleware_BadTokenRejected(t *testing.T) {
+	h := authMiddleware("secret", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(200) }))
+	req := httptest.NewRequest(http.MethodGet, "/x", nil)
+	req.Header.Set("Authorization", "Bearer wrong")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("got %d, want 401", rec.Code)
+	}
+}
+
+// --- SSE hub ----------------------------------------------------------------
+
+func TestSSEHub_BroadcastDeliversToSubscribers(t *testing.T) {
+	h := newSSEHub()
+	a := h.subscribe()
+	b := h.subscribe()
+
+	go h.broadcast("task-changed")
+
+	for _, ch := range []chan string{a, b} {
+		select {
+		case msg := <-ch:
+			if msg != "task-changed" {
+				t.Errorf("got %q, want task-changed", msg)
+			}
+		case <-time.After(time.Second):
+			t.Fatal("subscriber timed out")
+		}
+	}
+}
+
+func TestSSEHub_UnsubscribeRemovesClient(t *testing.T) {
+	h := newSSEHub()
+	a := h.subscribe()
+	h.unsubscribe(a)
+	// channel should be closed
+	select {
+	case _, ok := <-a:
+		if ok {
+			t.Error("expected channel closed on unsubscribe")
+		}
+	case <-time.After(time.Second):
+		t.Error("unsubscribe did not close channel")
+	}
+}
+
+func TestBroadcastChange_IsNilSafe(t *testing.T) {
+	srv, err := NewServer(":0", &kanbanStubProvider{plan: &planning.Plan{}, state: &planning.ExecutionState{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// sse is nil before Start(); should not panic.
+	srv.broadcastChange()
+}
+
+// --- Reopen on coordinator round-trip --------------------------------------
+
+func TestReopenTask_PropagatesThroughActions(t *testing.T) {
+	a := &fakeTaskActions{}
+	srv := newActionsServer(t, a)
+	rec := postForm(t, srv.handleTaskReopen, "/actions/task/reopen", url.Values{"id": {"t-1"}})
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("got %d, want 303", rec.Code)
+	}
+	if a.reopenCalled == nil {
+		t.Fatal("ReopenTask not invoked")
+	}
+}
+
+// Ensure dashboard.TaskActions interface stays compatible with the real
+// application.TaskService implementation we depend on.
+var _ TaskActions = (interface {
+	StartTask(ctx context.Context, taskID, owner, rateID string) error
+	CompleteTask(ctx context.Context, taskID, evidence string) ([]string, error)
+	BlockTask(ctx context.Context, taskID, reason string) error
+	UnblockTask(ctx context.Context, taskID string) error
+	ReopenTask(ctx context.Context, taskID string) error
+})(nil)


### PR DESCRIPTION
## Summary

Four backward-compatible polish features on top of v0.11.3's Kanban:

### 1. Reopen action
- New \`TaskService.ReopenTask\` + \`POST /actions/task/reopen\` move Done/Verified back to Pending.
- Done cards get a **↺ Reopen** button. DnD adds Done → Backlog / Ready transitions.

### 2. SSE live updates
- New \`GET /events\` stream broadcasts \`task-changed\` after every transition.
- Board reloads within ~200 ms (vs 30 s meta-refresh).
- Green \"live\" indicator in the header.
- 60 s meta-refresh + 25 s heartbeat retained as fallbacks.

### 3. Cross-project DnD on \`/org/kanban\`
- Cards carry \`project_path\` + \`project\` context.
- Action endpoints accept those form fields, routing through a new \`OrgTaskActions\` resolver.
- Wired automatically by \`roady dashboard serve\` (uses \`wiring.BuildAppServicesForProject\` internally).

### 4. Auth token
- \`--auth-token <v>\` flag (env: \`ROADY_DASHBOARD_TOKEN\`).
- Token accepted via \`Authorization: Bearer\`, \`Cookie: roady_token\`, or \`?token=\` handshake (sets cookie + redirects to strip secret from URL).
- Constant-time comparison; secure cookie on TLS.
- Empty token = public.

## Test plan

- [x] 13 new unit tests in \`v012_test.go\` covering reopen handler (happy/disabled), pickActions routing (default/org/error), org-routed start, auth middleware (public/reject/bearer/cookie/query/bad-token), SSE hub (broadcast/unsubscribe), broadcastChange nil-safety, interface stability.
- [x] Full \`go test ./...\` green
- [x] \`golangci-lint run --new-from-rev=origin/main ./...\` clean

## Try it

\`\`\`bash
# Public, single project
roady dashboard serve --port 3000

# With auth token
roady dashboard serve --port 3000 --auth-token \"\$(openssl rand -hex 16)\"

# Then open the URL with ?token=<value> once; cookie sticks for 30 days.
\`\`\`

Drag a Done card on \`/kanban\` onto Ready → reopens. Drag any card on \`/org/kanban\` between columns → cross-project mutation.

## Suggests v0.12.0

Minor bump (four new features, no breaking changes). Optional features default off when not wired by the embedder.