### PR TITLE
docs: update README + ROADMAP + new dashboard guide + website for v0.11/v0.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,53 @@ Status, drift, and progress all show in `roady status` — including a
 `from doc:line` citation for every task so the AI's choices stay
 auditable.
 
+## Live Kanban dashboard
+
+```bash
+roady dashboard serve --port 3000
+open http://localhost:3000/kanban
+```
+
+Five status columns (Backlog · Ready · In Progress · Blocked · Done).
+Click **Start / Complete / Block / Unblock / Reopen** or drag cards
+between columns — every drop is a real task transition. The board
+reloads within ~200 ms via Server-Sent Events.
+
+`/org/kanban` merges every project under the repo into a single
+cross-project board, so one agent juggling many feature streams sees
+the whole pipeline at once.
+
+For shared / remote use:
+
+```bash
+roady dashboard serve --port 3000 --auth-token "$(openssl rand -hex 16)"
+```
+
+Token accepted via `Authorization: Bearer`, `Cookie: roady_token`, or a
+one-time `?token=<value>` handshake. See [`docs/dashboard.md`](docs/dashboard.md).
+
+## Nested sub-projects
+
+One repository can host many Roady projects in parallel:
+
+```
+repo/
+  .roady/                          # root project
+  .roady/projects/feature-auth/    # named sub-project
+  .roady/projects/feature-payments/
+```
+
+```bash
+roady -P feature-auth init --template minimal
+roady -P feature-auth task ready
+ROADY_PROJECT=feature-auth roady status
+```
+
+Tasks, spec, plan, and state are namespaced per project. Coding agents
+switch context by passing `--project / -P <name>` (CLI) or `project`
+(MCP). Existing flat `.roady/` repos stay unchanged. See
+[`docs/rfcs/0001-nested-projects.md`](docs/rfcs/0001-nested-projects.md).
+
 ## What Roady is, and is not
 
 | Roady is... | Roady is not... |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -9,7 +9,32 @@ intended **open-core boundary** for a future hosted product.
 
 ---
 
-## Now (v0.10.x — shipped)
+## Now (v0.12.x — shipped)
+
+- **Live Kanban dashboard** at `/kanban` with five status columns
+  (Backlog / Ready / In Progress / Blocked / Done) and a `/api/kanban`
+  JSON endpoint. Click or drag to drive task transitions; board
+  reloads ~200 ms after every change via Server-Sent Events.
+- **Cross-project Kanban** at `/org/kanban` merges every project under
+  the repo (root + sub-projects) into one board; cards carry their
+  origin project and drops route to the right sub-project's
+  `TaskService`.
+- **Action endpoints**: `POST /actions/task/{start,complete,block,unblock,reopen}`,
+  form-encoded, accept optional `project_path` + `project` for org
+  routing.
+- **Dashboard auth token** (`--auth-token` flag or `ROADY_DASHBOARD_TOKEN`
+  env). Bearer / Cookie / one-time `?token=` handshake. Empty = public.
+
+## Recently (v0.11.x — shipped)
+
+- **Nested sub-projects** under `.roady/projects/<name>/`. One repo
+  hosts many projects in parallel; coding agents switch context with
+  `--project / -P <name>` (CLI) or `project` (MCP). Existing flat
+  `.roady/` repos unchanged. See
+  [`docs/rfcs/0001-nested-projects.md`](docs/rfcs/0001-nested-projects.md).
+- `roady discover` and `roady org status` surface sub-projects.
+
+## Earlier (v0.10.x — shipped)
 
 - Eval harness over heuristic + AI planners + drift corpus
 - Task provenance: `Origin` (heuristic / ai / human) + source citations
@@ -26,27 +51,28 @@ intended **open-core boundary** for a future hosted product.
 - `roady demo` for <1s aha; `roady init --interactive` default in TTY;
   empty-state ladder on `roady status`
 
-## Next (v0.11.x)
+## Next (v0.13.x)
 
-- **Positioning + narrative cleanup** (this release): one-page
-  positioning doc, README hero rewrite, advanced features moved to
-  `docs/advanced.md`, competitive comparison in `docs/vs.md`, this
-  roadmap.
-- **Website refresh** to mirror the README positioning.
-- Real provider matrix run via `-tags evals_ai` documented in
-  `evals/README.md` so contributors can self-serve a confidence check.
-
-## Soon (v0.12 — v0.13)
-
+- **Cross-project task dependencies** — `@project:task-id` syntax in
+  `DependsOn` so an org-level plan can express "feature-payments task
+  X waits on feature-auth task Y".
+- **Inline-edit on Kanban actions** — owner / evidence / reason
+  prompts on the dashboard instead of the current defaults
+  (`owner=dashboard`, `evidence="completed via dashboard"`).
 - **Drift explainer follow-ups**: synthesised "explain + propose patch"
   output that lands a PR-ready diff for accepted drift.
-- **Cross-repo planning**: a single `.roady/` workspace can declare
-  member repos, share spec context, and aggregate plan state.
 - **Per-task subagent dispatch**: `roady task start` can hand a ready
   task to a subagent (Claude Code `Task` tool, Codex `agent run`, etc.)
   with the spec source attached and a deterministic completion hook.
 - **Spec-to-PR loop**: CI integration that auto-detects drift on PR
   merge and either accepts or opens a follow-up issue.
+- **Touch-device Kanban DnD** — HTML5 DnD is desktop-only today;
+  mobile users still have the buttons.
+
+## Soon (v0.14+)
+
+- **Cross-repo planning**: a single `.roady/` workspace can declare
+  member repos, share spec context, and aggregate plan state.
 
 ## Later
 

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -1,0 +1,188 @@
+# Dashboard
+
+> **Status:** stable since v0.11.0 (Kanban) / v0.12.0 (live actions + auth)
+
+Roady ships a small web dashboard for any project. It surfaces the same
+data the CLI does — plan, tasks, drift, stats — but in a form you can
+keep open in a side tab while you and your agent work.
+
+## Start it
+
+```bash
+roady dashboard serve --port 3000
+```
+
+Routes:
+
+| Path | What you get |
+|---|---|
+| `/` | Stats grid + recent tasks |
+| `/plan` | Approved plan view |
+| `/tasks` | Flat task list with status pills |
+| `/kanban` | Five-column Kanban board (per-project) |
+| `/org/kanban` | Cross-project Kanban (root + every `.roady/projects/<name>/`) |
+| `/events` | Server-Sent Events stream (`task-changed`) |
+| `/api/plan`, `/api/state`, `/api/kanban`, `/api/org/kanban` | JSON for external tools |
+
+## Kanban
+
+Five status columns:
+
+- **Backlog** — pending tasks whose dependencies are not yet satisfied
+- **Ready** — pending tasks whose deps are all done/verified
+- **In Progress** — currently being worked on
+- **Blocked** — explicitly blocked with a reason
+- **Done** — completed (verified rolls into done for column purposes)
+
+### Click
+
+Each card has contextual buttons:
+
+| Column | Buttons |
+|---|---|
+| Ready | ▶ Start |
+| In Progress | ✓ Complete · ⊘ Block |
+| Blocked | ↺ Unblock |
+| Done | ↺ Reopen |
+
+### Drag-and-drop
+
+Drag any card to a target column. Allowed transitions show a green
+outline on drop hover; disallowed transitions show red (silently
+ignored).
+
+| From | To | Action |
+|---|---|---|
+| Ready | In Progress | start |
+| In Progress | Done | complete |
+| In Progress | Blocked | block |
+| Blocked | In Progress | unblock |
+| Done | Backlog / Ready | reopen |
+
+### Live updates
+
+The board subscribes to `/events` via `EventSource`. After every action
+the server broadcasts `task-changed` and connected clients reload
+within ~200 ms. A 25-second heartbeat keeps the stream alive through
+proxies (Cloudflare, nginx). A 60 s meta-refresh is kept as fallback
+for browsers without `EventSource`.
+
+## Cross-project Kanban (`/org/kanban`)
+
+When the workspace has nested sub-projects (see
+[`rfcs/0001-nested-projects.md`](rfcs/0001-nested-projects.md)),
+`/org/kanban` merges every project under the workspace root into one
+board. Cards are tagged with their origin project label
+(e.g. `repo/feature-auth`), and DnD drops route the mutation to the
+right sub-project's `TaskService` via the same
+`/actions/task/{start,complete,...}` endpoints with `project_path` +
+`project` form fields.
+
+The header strip lists every discovered project with task / done
+counts.
+
+## Action endpoints
+
+All form-encoded, all redirect 303 to the referring page. Mounted only
+when the server has task actions wired (the CLI does this
+automatically via `services.Task`).
+
+```
+POST /actions/task/start     (form: id, optional owner, project_path, project)
+POST /actions/task/complete  (form: id, optional evidence, project_path, project)
+POST /actions/task/block     (form: id, optional reason,   project_path, project)
+POST /actions/task/unblock   (form: id, optional project_path, project)
+POST /actions/task/reopen    (form: id, optional project_path, project)
+```
+
+When `project_path` and/or `project` are present, the request routes
+through `dashboard.OrgTaskActions.ResolveTaskActions` to the right
+sub-project's `TaskService`. Otherwise the server-default
+`taskActions` is used.
+
+## Auth
+
+The dashboard is public by default — fine for `localhost`, **not** fine
+if you put it behind a tunnel or share the URL. Protect it with a
+shared bearer token:
+
+```bash
+roady dashboard serve --port 3000 --auth-token "$(openssl rand -hex 16)"
+```
+
+Or via env:
+
+```bash
+ROADY_DASHBOARD_TOKEN="$(openssl rand -hex 16)" roady dashboard serve
+```
+
+Three ways to present the token:
+
+1. `Authorization: Bearer <token>` header (programmatic clients)
+2. `Cookie: roady_token=<token>` (browsers after one handshake)
+3. `?token=<token>` query — one-time handshake: the server sets the
+   cookie, redirects to strip the secret from the URL, then drops the
+   query. Share the `?token=` link once; the recipient stays logged in
+   for 30 days.
+
+Comparison is constant-time. The cookie is `Secure` over TLS / behind
+`X-Forwarded-Proto: https` (Cloudflare, nginx). Empty token = public.
+
+## Putting it behind a Cloudflare tunnel
+
+```bash
+# Terminal 1
+roady dashboard serve --port 3000 --auth-token "$(openssl rand -hex 16)"
+
+# Terminal 2 (separate machine or same)
+cloudflared tunnel --url http://localhost:3000
+```
+
+Cloudflare prints a `*.trycloudflare.com` URL. Append `?token=<value>`
+the first time you open it; the cookie sticks.
+
+For a persistent named tunnel + DNS, use
+[Cloudflare Zero Trust](https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/).
+
+## Limitations
+
+- HTML5 drag-and-drop is desktop-only. Mobile users have the buttons;
+  touch DnD is on the roadmap.
+- The board reloads on every change; large boards (>1k tasks) will
+  feel that. SSE delivers a diff hint but not the diff itself.
+- `/org/kanban` DnD requires the CLI to have wired
+  `OrgTaskActions` (default behaviour of `roady dashboard serve`).
+  Custom embedders need to call `Server.EnableOrgTaskActions`.
+
+## JSON shape
+
+`GET /api/kanban`:
+
+```json
+{
+  "columns": [
+    {"name": "Backlog", "status": "backlog", "tasks": [...], "count": 2},
+    {"name": "Ready",   "status": "ready",   "tasks": [...], "count": 4},
+    ...
+  ],
+  "project_name": "...",
+  "total_tasks": 33,
+  "updated_at": "2026-05-16T13:00:00Z"
+}
+```
+
+`GET /api/org/kanban` adds:
+
+```json
+{
+  "projects": [
+    {"label": "repo", "path": "/abs/path", "sub_project": "", "total": 33, "done": 23},
+    {"label": "repo/feature-auth", "path": "/abs/path/.roady/projects/feature-auth", "sub_project": "feature-auth", "total": 6, "done": 3}
+  ],
+  "total_tasks": 39,
+  "total_done": 26
+}
+```
+
+Cards include `Task`, `Status`, `Owner`, `ProjectLabel`, `ProjectPath`,
+`ProjectName` (last three populated on org boards).

--- a/website/src/components/CommandsSection.astro
+++ b/website/src/components/CommandsSection.astro
@@ -42,7 +42,14 @@
 <span class="text-violet-400">roady git sync</span>              <span class="text-gray-500"># state moves forward automatically</span>
 
 <span class="text-gray-500"># 5. Ask the question that matters</span>
-<span class="text-violet-400">roady drift detect</span>          <span class="text-gray-500"># has reality diverged from intent?</span></code></pre>
+<span class="text-violet-400">roady drift detect</span>          <span class="text-gray-500"># has reality diverged from intent?</span>
+
+<span class="text-gray-500"># Bonus — live Kanban (since v0.12); auth-token optional, drop for localhost</span>
+<span class="text-violet-400">roady dashboard serve</span>      <span class="text-gray-500"># open http://localhost:3000/kanban</span>
+
+<span class="text-gray-500"># Bonus — multiple projects per repo (since v0.11)</span>
+<span class="text-violet-400">roady</span> -P feature-auth <span class="text-violet-400">init</span> --template minimal
+<span class="text-violet-400">roady</span> -P feature-auth <span class="text-violet-400">task ready</span></code></pre>
       </div>
     </div>
 

--- a/website/src/components/FeaturesSection.astro
+++ b/website/src/components/FeaturesSection.astro
@@ -28,7 +28,7 @@
       </div>
     </div>
 
-    <div class="grid md:grid-cols-3 gap-8">
+    <div class="grid md:grid-cols-3 gap-8 mb-12">
       <!-- Step 1: Establish Intent -->
       <div class="glass p-8 rounded-3xl relative group hover:border-violet-500/50 transition-all">
         <div class="w-12 h-12 bg-violet-500/20 rounded-2xl flex items-center justify-center mb-6 text-violet-400">
@@ -68,6 +68,43 @@
         </p>
         <div class="mt-6 mono text-xs text-orange-300 bg-black/40 p-3 rounded-lg">
           $ roady drift detect
+        </div>
+      </div>
+    </div>
+
+    <!-- v0.11 + v0.12 surfaces: Kanban + nested projects -->
+    <div class="grid md:grid-cols-2 gap-8">
+      <!-- Live Kanban -->
+      <div class="glass p-8 rounded-3xl relative group hover:border-cyan-500/50 transition-all">
+        <div class="flex items-center mb-4">
+          <div class="w-12 h-12 bg-cyan-500/20 rounded-2xl flex items-center justify-center mr-4 text-cyan-400">
+            <i data-lucide="kanban-square"></i>
+          </div>
+          <span class="text-xs uppercase tracking-wide font-semibold text-cyan-400">new · v0.12</span>
+        </div>
+        <h3 class="text-xl font-bold text-white mb-3">Live Kanban dashboard</h3>
+        <p class="text-sm leading-relaxed text-gray-400 mb-4">
+          Five-column board (Backlog · Ready · In Progress · Blocked · Done) with click-or-drag transitions. Reloads ~200&nbsp;ms after every change via Server-Sent Events. Optional <code class="mono text-violet-400">--auth-token</code> for shared / tunneled access.
+        </p>
+        <div class="mono text-xs text-cyan-300 bg-black/40 p-3 rounded-lg">
+          $ roady dashboard serve --port 3000
+        </div>
+      </div>
+
+      <!-- Nested sub-projects -->
+      <div class="glass p-8 rounded-3xl relative group hover:border-purple-500/50 transition-all">
+        <div class="flex items-center mb-4">
+          <div class="w-12 h-12 bg-purple-500/20 rounded-2xl flex items-center justify-center mr-4 text-purple-400">
+            <i data-lucide="layers"></i>
+          </div>
+          <span class="text-xs uppercase tracking-wide font-semibold text-purple-400">new · v0.11</span>
+        </div>
+        <h3 class="text-xl font-bold text-white mb-3">Nested sub-projects</h3>
+        <p class="text-sm leading-relaxed text-gray-400 mb-4">
+          One repo, many parallel projects under <code class="mono text-violet-400">.roady/projects/&lt;name&gt;/</code>. One agent juggles them by passing <code class="mono text-violet-400">--project / -P</code> (CLI) or <code class="mono text-violet-400">project</code> (MCP). Cross-project view at <code class="mono text-violet-400">/org/kanban</code>.
+        </p>
+        <div class="mono text-xs text-purple-300 bg-black/40 p-3 rounded-lg">
+          $ roady -P feature-auth task ready
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

Docs were behind by two releases (v0.11.0 and v0.12.0 shipped without README / ROADMAP / website updates). This PR closes the gap:

- **README** — adds \"Live Kanban dashboard\" + \"Nested sub-projects\" sections directly under the headline workflow.
- **ROADMAP** — promotes v0.11 (nested projects) + v0.12 (Kanban / SSE / org DnD / auth) from \"Next/Soon\" to \"Now/Recently shipped\". Refreshes the v0.13.x next list.
- **docs/dashboard.md (new)** — full reference: routes, Kanban columns, click + drag actions, SSE, auth token (Bearer / Cookie / one-time \`?token=\` handshake), Cloudflare tunnel recipe, JSON shape.
- **website FeaturesSection** — two new tiles below the 3-step workflow showing the Kanban + nested-projects surfaces.
- **website CommandsSection** — adds dashboard + \`-P\` examples to the code block.

No code changes.

## Test plan

- [x] \`grep -ri\` for the new feature names lands in README / ROADMAP / docs/dashboard.md / website components, not just CHANGELOG.
- [x] Astro components syntactically clean (existing pattern matched).
- [x] All cross-links resolve.