### PR TITLE
chore(deps): bump go.klarlabs.de/mcp to v1.22.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/xeipuuv/gojsonschema v1.2.0
 	go.klarlabs.de/fortify v1.8.1
-	go.klarlabs.de/mcp v1.21.0
+	go.klarlabs.de/mcp v1.22.0
 	go.klarlabs.de/statekit v1.8.0
 	golang.org/x/oauth2 v0.36.0
 	google.golang.org/grpc v1.82.0

--- a/go.sum
+++ b/go.sum
@@ -121,8 +121,8 @@ github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavM
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
 go.klarlabs.de/fortify v1.8.1 h1:gyzJ7ESNe/Qf65DhGCT1WPWDyphgEDApb2QTx3Gd2m0=
 go.klarlabs.de/fortify v1.8.1/go.mod h1:x4Rnk8xt8ckJ8Pxe5SsXZVfGYjJIoOHx67DBl5Ncis8=
-go.klarlabs.de/mcp v1.21.0 h1:SFf0Cr2rPYhLw0VnW1eec7y77vFddfEGXsPCv1ixEWs=
-go.klarlabs.de/mcp v1.21.0/go.mod h1:ZeezqVm3aJFDN2+a7W0BVrLcEDhD2tdA+tQb+Klv5FE=
+go.klarlabs.de/mcp v1.22.0 h1:2ufVDqJT2/+kt5zd8B9HjbxJUbz3DYEVe43PqwTQ/QI=
+go.klarlabs.de/mcp v1.22.0/go.mod h1:ZeezqVm3aJFDN2+a7W0BVrLcEDhD2tdA+tQb+Klv5FE=
 go.klarlabs.de/statekit v1.8.0 h1:bOTAuextbB46f2tzXs9zpZ5qdwLIzE1e8OE5eDPv6fM=
 go.klarlabs.de/statekit v1.8.0/go.mod h1:ZYFkCAGSdRm/jx7QDvVqWsGwRZGc8ndhE7dk7NtsE7E=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=


### PR DESCRIPTION
Bumps the MCP framework to **v1.22.0**.

All changes across this range are additive / opt-in, so no source changes are required. Free wins:
- Deterministic `tools/list` ordering
- Full JSON Schema 2020-12 for `inputSchema`/`outputSchema`
- Modern MCP error codes and `server/discover` stateless foundation (opt-in)

**Verification:** `go mod tidy`, `go build ./...`, and `go test ./...` run locally.

https://claude.ai/code/session_01LCyhyAffdzBmzG3yPPqzTT