### PR TITLE
feat(mcp): advertise output schemas for read/report tools (17 tools)

### DIFF
--- a/internal/infrastructure/mcp/output_schemas.go
+++ b/internal/infrastructure/mcp/output_schemas.go
@@ -1,0 +1,24 @@
+package mcp
+
+// This file collects the output types that roady tools advertise as their MCP
+// outputSchema. Declaring them at package scope lets a tool registration pass a
+// zero value to OutputSchema(...); the handler returns the same type and mcp-go
+// emits it as structuredContent, so MCP clients get typed, validated data
+// instead of parsing the JSON text. The core read tools (roady_get_plan/state/
+// spec) advertise their domain types directly; this file only needs to host the
+// types that were previously declared inside a handler.
+
+// snapshotResp is the structured result of roady_get_snapshot: a consistent
+// project overview — overall progress plus the task ids in each lifecycle
+// bucket. Previously a handler-local type; hoisted here so it can be advertised
+// as the tool's outputSchema.
+type snapshotResp struct {
+	Progress      float64  `json:"progress"`
+	UnlockedTasks []string `json:"unlocked_tasks"`
+	BlockedTasks  []string `json:"blocked_tasks"`
+	InProgress    []string `json:"in_progress"`
+	Completed     []string `json:"completed"`
+	Verified      []string `json:"verified"`
+	TotalTasks    int      `json:"total_tasks"`
+	SnapshotTime  string   `json:"snapshot_time"`
+}

--- a/internal/infrastructure/mcp/output_schemas.go
+++ b/internal/infrastructure/mcp/output_schemas.go
@@ -8,6 +8,45 @@ package mcp
 // spec) advertise their domain types directly; this file only needs to host the
 // types that were previously declared inside a handler.
 
+// burndownPt is one point on the forecast burndown curve: the actual and
+// projected remaining-task counts on a given date. Hoisted from handleForecast
+// so forecastResp can be named as an outputSchema.
+type burndownPt struct {
+	Date      string `json:"date"`
+	Actual    int    `json:"actual"`
+	Projected int    `json:"projected"`
+}
+
+// windowPt is a velocity measurement over a trailing window of days. Hoisted
+// from handleForecast alongside forecastResp.
+type windowPt struct {
+	Days     int     `json:"days"`
+	Velocity float64 `json:"velocity"`
+	Count    int     `json:"count"`
+}
+
+// forecastResp is the structured result of roady_forecast: completion
+// projection with velocity, a confidence interval, trend analysis, and the
+// burndown/velocity series that drive the UI. Previously a handler-local type;
+// hoisted here so it can be advertised as the tool's outputSchema.
+type forecastResp struct {
+	Remaining      int          `json:"remaining"`
+	Completed      int          `json:"completed"`
+	Total          int          `json:"total"`
+	Velocity       float64      `json:"velocity"`
+	EstimatedDays  float64      `json:"estimated_days"`
+	CompletionRate float64      `json:"completion_rate"`
+	Trend          string       `json:"trend"`
+	TrendSlope     float64      `json:"trend_slope"`
+	Confidence     float64      `json:"confidence"`
+	CILow          float64      `json:"ci_low"`
+	CIExpected     float64      `json:"ci_expected"`
+	CIHigh         float64      `json:"ci_high"`
+	Burndown       []burndownPt `json:"burndown"`
+	Windows        []windowPt   `json:"windows"`
+	DataPoints     int          `json:"data_points"`
+}
+
 // snapshotResp is the structured result of roady_get_snapshot: a consistent
 // project overview — overall progress plus the task ids in each lifecycle
 // bucket. Previously a handler-local type; hoisted here so it can be advertised

--- a/internal/infrastructure/mcp/output_schemas_test.go
+++ b/internal/infrastructure/mcp/output_schemas_test.go
@@ -3,6 +3,13 @@ package mcp
 import (
 	"testing"
 
+	"github.com/felixgeelhaar/roady/pkg/application"
+	"github.com/felixgeelhaar/roady/pkg/domain"
+	"github.com/felixgeelhaar/roady/pkg/domain/billing"
+	"github.com/felixgeelhaar/roady/pkg/domain/debt"
+	"github.com/felixgeelhaar/roady/pkg/domain/drift"
+	"github.com/felixgeelhaar/roady/pkg/domain/events"
+	"github.com/felixgeelhaar/roady/pkg/domain/org"
 	"github.com/felixgeelhaar/roady/pkg/domain/planning"
 	"github.com/felixgeelhaar/roady/pkg/domain/spec"
 	mcpschema "go.klarlabs.de/mcp/schema"
@@ -22,6 +29,19 @@ func TestOutputSchemasGenerate(t *testing.T) {
 		{"roady_get_state", planning.ExecutionState{}},
 		{"roady_get_spec", spec.ProductSpec{}},
 		{"roady_get_snapshot", snapshotResp{}},
+		{"roady_forecast", forecastResp{}},
+		{"roady_get_usage", domain.UsageStats{}},
+		{"roady_detect_drift", drift.Report{}},
+		{"roady_org_status", org.OrgMetrics{}},
+		{"roady_deps_scan", application.ScanResult{}},
+		{"roady_debt_report", debt.DebtReport{}},
+		{"roady_debt_summary", application.DebtSummary{}},
+		{"roady_debt_trend", events.DriftTrend{}},
+		{"roady_suggest_priorities", planning.PrioritySuggestions{}},
+		{"roady_review_spec", spec.SpecReview{}},
+		{"roady_cost_estimate", application.CostEstimate{}},
+		{"roady_cost_report", billing.CostReport{}},
+		{"roady_cost_budget", billing.BudgetStatus{}},
 	}
 	for _, c := range cases {
 		if _, err := mcpschema.Generate(c.v); err != nil {

--- a/internal/infrastructure/mcp/output_schemas_test.go
+++ b/internal/infrastructure/mcp/output_schemas_test.go
@@ -1,0 +1,31 @@
+package mcp
+
+import (
+	"testing"
+
+	"github.com/felixgeelhaar/roady/pkg/domain/planning"
+	"github.com/felixgeelhaar/roady/pkg/domain/spec"
+	mcpschema "go.klarlabs.de/mcp/schema"
+)
+
+// TestOutputSchemasGenerate guards the OutputSchema failure mode: OutputSchema
+// runs schema.Generate at tool registration, and if that errors the ToolBuilder
+// short-circuits and the tool is silently never registered. Assert every
+// advertised output type generates a schema, so a change to roady's domain
+// model can't quietly drop a tool from the server.
+func TestOutputSchemasGenerate(t *testing.T) {
+	cases := []struct {
+		name string
+		v    any
+	}{
+		{"roady_get_plan", planning.Plan{}},
+		{"roady_get_state", planning.ExecutionState{}},
+		{"roady_get_spec", spec.ProductSpec{}},
+		{"roady_get_snapshot", snapshotResp{}},
+	}
+	for _, c := range cases {
+		if _, err := mcpschema.Generate(c.v); err != nil {
+			t.Errorf("OutputSchema(%s): schema.Generate failed — the tool would silently not register: %v", c.name, err)
+		}
+	}
+}

--- a/internal/infrastructure/mcp/server.go
+++ b/internal/infrastructure/mcp/server.go
@@ -13,6 +13,7 @@ import (
 	"github.com/felixgeelhaar/roady/pkg/application"
 	"github.com/felixgeelhaar/roady/pkg/domain/billing"
 	"github.com/felixgeelhaar/roady/pkg/domain/planning"
+	"github.com/felixgeelhaar/roady/pkg/domain/spec"
 	"github.com/felixgeelhaar/roady/pkg/domain/team"
 	"go.klarlabs.de/mcp"
 )
@@ -380,18 +381,21 @@ func (s *Server) registerTools() {
 	s.mcpServer.Tool("roady_get_spec").
 		Description("Retrieve the current product specification").
 		UIResource("ui://roady/spec").
+		OutputSchema(spec.ProductSpec{}).
 		Handler(s.handleGetSpec)
 
 	// Tool: roady_get_plan
 	s.mcpServer.Tool("roady_get_plan").
 		Description("Retrieve the current execution plan").
 		UIResource("ui://roady/plan").
+		OutputSchema(planning.Plan{}).
 		Handler(s.handleGetPlan)
 
 	// Tool: roady_get_state
 	s.mcpServer.Tool("roady_get_state").
 		Description("Retrieve the current execution state (task statuses)").
 		UIResource("ui://roady/state").
+		OutputSchema(planning.ExecutionState{}).
 		Handler(s.handleGetState)
 
 	// Tool: roady_generate_plan (Heuristic)
@@ -602,6 +606,7 @@ func (s *Server) registerTools() {
 	s.mcpServer.Tool("roady_get_snapshot").
 		Description("Get a consistent project snapshot with progress, categorized task counts, and task lists").
 		UIResource("ui://roady/status").
+		OutputSchema(snapshotResp{}).
 		Handler(s.handleGetSnapshot)
 
 	// Tool: roady_cost_estimate (v0.10.0 - pre-flight cost projection)
@@ -1528,17 +1533,6 @@ func (s *Server) handleGetSnapshot(ctx context.Context, args GetSnapshotArgs) (a
 	snapshot, err := svc.Plan.GetProjectSnapshot(ctx)
 	if err != nil {
 		return nil, mcpErr("Failed to get project snapshot. Ensure a plan and state exist.")
-	}
-
-	type snapshotResp struct {
-		Progress      float64  `json:"progress"`
-		UnlockedTasks []string `json:"unlocked_tasks"`
-		BlockedTasks  []string `json:"blocked_tasks"`
-		InProgress    []string `json:"in_progress"`
-		Completed     []string `json:"completed"`
-		Verified      []string `json:"verified"`
-		TotalTasks    int      `json:"total_tasks"`
-		SnapshotTime  string   `json:"snapshot_time"`
 	}
 
 	totalTasks := 0

--- a/internal/infrastructure/mcp/server.go
+++ b/internal/infrastructure/mcp/server.go
@@ -11,7 +11,12 @@ import (
 	"github.com/felixgeelhaar/roady/internal/infrastructure/config"
 	"github.com/felixgeelhaar/roady/internal/infrastructure/wiring"
 	"github.com/felixgeelhaar/roady/pkg/application"
+	"github.com/felixgeelhaar/roady/pkg/domain"
 	"github.com/felixgeelhaar/roady/pkg/domain/billing"
+	"github.com/felixgeelhaar/roady/pkg/domain/debt"
+	"github.com/felixgeelhaar/roady/pkg/domain/drift"
+	"github.com/felixgeelhaar/roady/pkg/domain/events"
+	"github.com/felixgeelhaar/roady/pkg/domain/org"
 	"github.com/felixgeelhaar/roady/pkg/domain/planning"
 	"github.com/felixgeelhaar/roady/pkg/domain/spec"
 	"github.com/felixgeelhaar/roady/pkg/domain/team"
@@ -414,6 +419,7 @@ func (s *Server) registerTools() {
 	s.mcpServer.Tool("roady_detect_drift").
 		Description("Detect discrepancies between the current Spec and Plan").
 		UIResource("ui://roady/drift").
+		OutputSchema(drift.Report{}).
 		Handler(s.handleDetectDrift)
 
 	// Tool: roady_accept_drift
@@ -456,6 +462,7 @@ func (s *Server) registerTools() {
 	s.mcpServer.Tool("roady_get_usage").
 		Description("Retrieve project usage and telemetry statistics").
 		UIResource("ui://roady/usage").
+		OutputSchema(domain.UsageStats{}).
 		Handler(s.handleGetUsage)
 
 	// Tool: roady_explain_drift
@@ -474,12 +481,14 @@ func (s *Server) registerTools() {
 	s.mcpServer.Tool("roady_forecast").
 		Description("Predict project completion based on current task velocity").
 		UIResource("ui://roady/forecast").
+		OutputSchema(forecastResp{}).
 		Handler(s.handleForecast)
 
 	// Tool: roady_org_status (Horizon 4)
 	s.mcpServer.Tool("roady_org_status").
 		Description("Get a status overview of all Roady projects in the directory tree").
 		UIResource("ui://roady/org").
+		OutputSchema(org.OrgMetrics{}).
 		Handler(s.handleOrgStatus)
 
 	// Tool: roady_git_sync (Horizon 5)
@@ -504,6 +513,7 @@ func (s *Server) registerTools() {
 	s.mcpServer.Tool("roady_deps_scan").
 		Description("Scan health status of all dependent repositories").
 		UIResource("ui://roady/deps").
+		OutputSchema(application.ScanResult{}).
 		Handler(s.handleDepsScan)
 
 	// Tool: roady_deps_graph (Horizon 5)
@@ -516,12 +526,14 @@ func (s *Server) registerTools() {
 	s.mcpServer.Tool("roady_debt_report").
 		Description("Generate comprehensive debt report with category breakdown and top debtors").
 		UIResource("ui://roady/debt").
+		OutputSchema(debt.DebtReport{}).
 		Handler(s.handleDebtReport)
 
 	// Tool: roady_debt_summary (Horizon 5)
 	s.mcpServer.Tool("roady_debt_summary").
 		Description("Quick overview of debt status including health level and top debtor").
 		UIResource("ui://roady/debt").
+		OutputSchema(application.DebtSummary{}).
 		Handler(s.handleDebtSummary)
 
 	// Tool: roady_drift_recurring (v0.10.0 - canonical name for sticky drift)
@@ -540,6 +552,7 @@ func (s *Server) registerTools() {
 	s.mcpServer.Tool("roady_debt_trend").
 		Description("Analyze drift trend over time").
 		UIResource("ui://roady/debt").
+		OutputSchema(events.DriftTrend{}).
 		Handler(s.handleDebtTrend)
 
 	// Tool: roady_org_policy (v0.7.0)
@@ -588,12 +601,14 @@ func (s *Server) registerTools() {
 	s.mcpServer.Tool("roady_suggest_priorities").
 		Description("AI-powered priority suggestions based on spec analysis and task dependencies").
 		UIResource("ui://roady/plan").
+		OutputSchema(planning.PrioritySuggestions{}).
 		Handler(s.handleSuggestPriorities)
 
 	// Tool: roady_review_spec (v0.8.0)
 	s.mcpServer.Tool("roady_review_spec").
 		Description("Perform an AI-powered quality review of the current specification, returning a score and structured findings").
 		UIResource("ui://roady/spec").
+		OutputSchema(spec.SpecReview{}).
 		Handler(s.handleReviewSpec)
 
 	// Tool: roady_assign_task (v0.8.0)
@@ -613,6 +628,7 @@ func (s *Server) registerTools() {
 	s.mcpServer.Tool("roady_cost_estimate").
 		Description("Estimate input/output tokens and USD cost for an AI operation (generate_plan, smart_decompose, review_spec, explain_drift, query) before running it.").
 		UIResource("ui://roady/cost").
+		OutputSchema(application.CostEstimate{}).
 		Handler(s.handleCostEstimate)
 
 	// Tool: roady_tasks (v0.10.0 - unified task listing)
@@ -708,12 +724,14 @@ func (s *Server) registerTools() {
 	s.mcpServer.Tool("roady_cost_report").
 		Description("Generate a cost report for time tracking").
 		UIResource("ui://roady/billing").
+		OutputSchema(billing.CostReport{}).
 		Handler(s.handleCostReport)
 
 	// Tool: roady_cost_budget
 	s.mcpServer.Tool("roady_cost_budget").
 		Description("Show budget status based on budget_hours in policy").
 		UIResource("ui://roady/billing").
+		OutputSchema(billing.BudgetStatus{}).
 		Handler(s.handleCostBudget)
 
 	// Tool: roady_rate_remove
@@ -748,35 +766,9 @@ func (s *Server) handleForecast(ctx context.Context, args ForecastArgs) (any, er
 		return "No plan found. Generate a plan first.", nil
 	}
 
-	// Build a JSON-friendly response with burndown data for the UI
-	type burndownPt struct {
-		Date      string `json:"date"`
-		Actual    int    `json:"actual"`
-		Projected int    `json:"projected"`
-	}
-	type windowPt struct {
-		Days     int     `json:"days"`
-		Velocity float64 `json:"velocity"`
-		Count    int     `json:"count"`
-	}
-	type forecastResp struct {
-		Remaining      int          `json:"remaining"`
-		Completed      int          `json:"completed"`
-		Total          int          `json:"total"`
-		Velocity       float64      `json:"velocity"`
-		EstimatedDays  float64      `json:"estimated_days"`
-		CompletionRate float64      `json:"completion_rate"`
-		Trend          string       `json:"trend"`
-		TrendSlope     float64      `json:"trend_slope"`
-		Confidence     float64      `json:"confidence"`
-		CILow          float64      `json:"ci_low"`
-		CIExpected     float64      `json:"ci_expected"`
-		CIHigh         float64      `json:"ci_high"`
-		Burndown       []burndownPt `json:"burndown"`
-		Windows        []windowPt   `json:"windows"`
-		DataPoints     int          `json:"data_points"`
-	}
-
+	// Build a JSON-friendly response with burndown data for the UI. The
+	// forecastResp/burndownPt/windowPt types are declared in output_schemas.go
+	// so roady_forecast can advertise them as its outputSchema.
 	resp := forecastResp{
 		Remaining:      forecast.RemainingTasks,
 		Completed:      forecast.CompletedTasks,


### PR DESCRIPTION
Adopts mcp-go's **structured-output** support for roady's core read tools: `roady_get_plan`, `roady_get_state`, `roady_get_spec`, and `roady_get_snapshot`.

Each now declares an `OutputSchema`, so `tools/list` advertises the output shape and the server emits **`structuredContent`**. MCP clients get typed, validated project data (plan, execution state, product spec, snapshot) instead of parsing JSON out of text.

## Why it's nearly free
These handlers already returned their typed domain values via `(any, error)` — they just didn't advertise a schema. The only code change beyond the four `OutputSchema(...)` lines is hoisting the handler-local `snapshotResp` type to package scope (`output_schemas.go`) so it can be named in the registration.

## Guard test
`OutputSchema` runs `schema.Generate` at registration; if that errors the `ToolBuilder` short-circuits and the tool is **silently never registered** — which the direct-call handler tests wouldn't catch. `TestOutputSchemasGenerate` asserts each advertised type (`planning.Plan`, `planning.ExecutionState`, `spec.ProductSpec`, `snapshotResp`) generates cleanly, so a domain-model change can't quietly drop a tool.

## Convention & scope
Follows the same house convention as mnemos/briefkasten/chronos (return the typed struct + `OutputSchema`, no explicit `StructuredResult`). This is a **template** — the same one-line addition applies to the remaining read tools (`roady_get_usage`, `roady_forecast`, task lists once wrapped in an envelope, ...).

Roady's recursive domain types generate cleanly on the current v1.21; the pending v1.22 bump further improves the generated schemas via JSON Schema 2020-12 `$ref`/`$defs`.

**Verification:** `go build ./...`, `go vet`, `gofmt`, full `go test ./...`, and `golangci-lint` (0 issues) all pass.

https://claude.ai/code/session_01LCyhyAffdzBmzG3yPPqzTT