### PR TITLE
fix(webhook,watch): close the data races the -race build was failing on

### DIFF
--- a/internal/infrastructure/watch/watcher_test.go
+++ b/internal/infrastructure/watch/watcher_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -21,11 +22,16 @@ func TestFSWatcher_DetectsFileWrite(t *testing.T) {
 	}
 
 	var eventCount atomic.Int32
+	// lastChange is written from the watcher's callback goroutine and read here,
+	// so it needs the same protection eventCount already gets from being atomic.
+	var mu sync.Mutex
 	var lastChange ChangeEvent
 
 	w, err := NewFSWatcher(50*time.Millisecond, func(e ChangeEvent) {
 		eventCount.Add(1)
+		mu.Lock()
 		lastChange = e
+		mu.Unlock()
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -57,7 +63,10 @@ func TestFSWatcher_DetectsFileWrite(t *testing.T) {
 	if eventCount.Load() == 0 {
 		t.Error("expected at least one change event")
 	}
-	if lastChange.ChangeType == "" {
+	mu.Lock()
+	gotType := lastChange.ChangeType
+	mu.Unlock()
+	if gotType == "" {
 		t.Error("expected a non-empty change type")
 	}
 }

--- a/internal/infrastructure/webhook/notifier_test.go
+++ b/internal/infrastructure/webhook/notifier_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -44,12 +45,18 @@ func TestNotifier_DeliverySuccess(t *testing.T) {
 
 func TestNotifier_HMACSignature(t *testing.T) {
 	secret := "test-secret"
+	// The handler runs on the server's goroutine and the assertions below run on
+	// the test's, so everything crossing that boundary needs a lock.
+	var mu sync.Mutex
 	var receivedSig string
 	var receivedBody []byte
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		receivedSig = r.Header.Get("X-Roady-Signature")
-		receivedBody, _ = io.ReadAll(r.Body)
+		sig := r.Header.Get("X-Roady-Signature")
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		receivedSig, receivedBody = sig, body
+		mu.Unlock()
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer server.Close()
@@ -67,17 +74,21 @@ func TestNotifier_HMACSignature(t *testing.T) {
 
 	time.Sleep(200 * time.Millisecond)
 
-	if receivedSig == "" {
+	mu.Lock()
+	gotSig, gotBody := receivedSig, receivedBody
+	mu.Unlock()
+
+	if gotSig == "" {
 		t.Fatal("expected X-Roady-Signature header")
 	}
 
 	// Verify signature
 	mac := hmac.New(sha256.New, []byte(secret))
-	mac.Write(receivedBody)
+	mac.Write(gotBody)
 	expected := "sha256=" + hex.EncodeToString(mac.Sum(nil))
 
-	if receivedSig != expected {
-		t.Errorf("signature mismatch: got %s, want %s", receivedSig, expected)
+	if gotSig != expected {
+		t.Errorf("signature mismatch: got %s, want %s", gotSig, expected)
 	}
 }
 
@@ -158,13 +169,20 @@ func TestNotifier_EventFilter(t *testing.T) {
 }
 
 func TestPayloadFormat(t *testing.T) {
+	// Guarded for the same reason, and the decode error is carried back to the
+	// test goroutine rather than reported with t.Fatal from the handler's —
+	// t.Fatal must be called from the goroutine running the test.
+	var mu sync.Mutex
 	var receivedPayload Payload
+	var decodeErr error
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, _ := io.ReadAll(r.Body)
-		if err := json.Unmarshal(body, &receivedPayload); err != nil {
-			t.Fatal(err)
-		}
+		var p Payload
+		err := json.Unmarshal(body, &p)
+		mu.Lock()
+		receivedPayload, decodeErr = p, err
+		mu.Unlock()
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer server.Close()
@@ -176,7 +194,14 @@ func TestPayloadFormat(t *testing.T) {
 
 	time.Sleep(200 * time.Millisecond)
 
-	if receivedPayload.EventType != "plan.created" {
-		t.Errorf("expected event_type plan.created, got %s", receivedPayload.EventType)
+	mu.Lock()
+	got, err := receivedPayload, decodeErr
+	mu.Unlock()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.EventType != "plan.created" {
+		t.Errorf("expected event_type plan.created, got %s", got.EventType)
 	}
 }

--- a/pkg/infrastructure/webhook/server.go
+++ b/pkg/infrastructure/webhook/server.go
@@ -95,23 +95,37 @@ func (s *Server) Start() error {
 	// Recent events endpoint (for debugging)
 	mux.HandleFunc("/events", s.handleEvents)
 
-	s.server = &http.Server{
+	srv := &http.Server{
 		Addr:         s.addr,
 		Handler:      mux,
 		ReadTimeout:  15 * time.Second,
 		WriteTimeout: 15 * time.Second,
 	}
+	// Publish under the lock, then serve through the local copy. ListenAndServe
+	// blocks for the life of the server, so every caller runs Start in its own
+	// goroutine and Shutdown from another — an unguarded s.server is read and
+	// written concurrently by definition, not just under test.
+	s.mu.Lock()
+	s.server = srv
+	s.mu.Unlock()
 
 	log.Printf("Webhook server starting on %s", s.addr)
-	return s.server.ListenAndServe()
+	return srv.ListenAndServe()
 }
 
-// Shutdown gracefully shuts down the server.
+// Shutdown gracefully shuts down the server. Shutting down a server that was
+// never started is a no-op, so racing Shutdown ahead of Start returns nil
+// rather than blocking.
 func (s *Server) Shutdown(ctx context.Context) error {
-	if s.server == nil {
+	s.mu.RLock()
+	srv := s.server
+	s.mu.RUnlock()
+	if srv == nil {
 		return nil
 	}
-	return s.server.Shutdown(ctx)
+	// Shutdown outside the lock: it blocks until connections drain, and holding
+	// the mutex would stall every in-flight handler that needs it.
+	return srv.Shutdown(ctx)
 }
 
 func (s *Server) handleWebhook(provider string) http.HandlerFunc {


### PR DESCRIPTION
## The suite was red under -race

`go test ./...` passes. `go test -race ./...` did not — in **three** packages. CI and warden's `gotest` step both run with `-race`, so the suite was failing for anyone running it the way the gate does; a plain local run said everything was fine.

Found while trying to push an unrelated one-line release-config change, which the gate refused because of these.

## One of them is a production bug

`pkg/infrastructure/webhook`: `Server.Start` assigned `s.server` and `Shutdown` read it with no synchronisation, while the struct's mutex guarded only `handlers` and `secrets`.

`ListenAndServe` blocks for the life of the server, so **every correct caller** runs `Start` in its own goroutine and calls `Shutdown` from another — the two touch `s.server` concurrently by construction. The test is only where `-race` happens to observe it.

The handle is now published under the lock and served through a local copy, so neither path holds the mutex while blocking: `Shutdown` waits for connections to drain, and holding the lock there would stall every in-flight handler that needs it.

## The other two are test-side, same shape

A value written on a callback or `http.Handler` goroutine and read from the test goroutine:

- `internal/infrastructure/watch` guarded its event counter with an atomic but left `lastChange` unprotected.
- `internal/infrastructure/webhook` did the same with the received signature, body and payload. That handler also called `t.Fatal`, which must come from the goroutine running the test — the decode error is now carried back and reported there.

## Verification

`go test -race ./...` is clean. Reverting the server fix reproduces three data races in `TestServer_StartAndShutdown`, so the existing test does catch it once `-race` is on.

https://claude.ai/code/session_01BFsL9VmX5KHW8cnLMRPei3