### PR TITLE
chore(release): publish the formula to the klarlabs-studio tap

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -112,10 +112,14 @@ changelog:
       - '^test:'
       - '^chore\(\.roady\):'
 
+# The tap is the one owned by the org that owns this repo, which is also the
+# scope HOMEBREW_TAP_TOKEN — a klarlabs-studio org secret — can write to. An
+# org secret does not reach a personal repo, which answers 403: briefkasten's
+# v0.31.0 published every artifact and then failed exactly there.
 brews:
   - name: roady
     repository:
-      owner: felixgeelhaar
+      owner: klarlabs-studio
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
     directory: Formula


### PR DESCRIPTION
> **Stacked on #61.** Based on `fix/webhook-server-race`, because the gate runs the suite with `-race` and it was red without those fixes. Merge #61 first and this retargets to `main` automatically; the diff here is one config block.

## Why

roady is a `klarlabs-studio` repo and `HOMEBREW_TAP_TOKEN` is a `klarlabs-studio` org secret — but the formula was pointed at `felixgeelhaar/homebrew-tap`, a personal repo that secret cannot reach.

briefkasten hit that combination first: v0.31.0 published all 22 signed artifacts and then failed on the brew step with

```
403 Resource not accessible by personal access token
```

A `403` rather than a `401` is the fine-grained-PAT signature — it authenticated, but the target repo is outside its scope.

## Sequencing note for whoever merges

`roady.rb` exists **only** in the personal tap. So the first release after this lands creates it in the org tap, and the personal-tap copy stops being updated — anyone installed from `felixgeelhaar/tap` silently pins to their current version.

A `tap_migrations.json` entry in the personal tap (`{"roady": "klarlabs-studio/tap"}`) carries them over, but it has to come **after** that first release: a redirect pointing at a tap that does not yet hold the formula breaks the very install it exists to preserve. Neither tap contains that file today.

## Note for a follow-up

`goreleaser check` reports the config *"uses deprecated properties"* — `brews:` was deprecated in GoReleaser v2.16 in favour of `homebrew_casks:`. That predates this PR and is left alone to keep the change to one line of intent.

https://claude.ai/code/session_01BFsL9VmX5KHW8cnLMRPei3