### PR TITLE
chore(release): publish the formula to the klarlabs-studio tap

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -112,10 +112,14 @@ changelog:
       - '^test:'
       - '^chore\(\.roady\):'
 
+# The tap is the one owned by the org that owns this repo, which is also the
+# scope HOMEBREW_TAP_TOKEN — a klarlabs-studio org secret — can write to. An
+# org secret does not reach a personal repo, which answers 403: briefkasten's
+# v0.31.0 published every artifact and then failed exactly there.
 brews:
   - name: roady
     repository:
-      owner: felixgeelhaar
+      owner: klarlabs-studio
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
     directory: Formula

--- a/internal/infrastructure/watch/watcher_test.go
+++ b/internal/infrastructure/watch/watcher_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -21,11 +22,16 @@ func TestFSWatcher_DetectsFileWrite(t *testing.T) {
 	}
 
 	var eventCount atomic.Int32
+	// lastChange is written from the watcher's callback goroutine and read here,
+	// so it needs the same protection eventCount already gets from being atomic.
+	var mu sync.Mutex
 	var lastChange ChangeEvent
 
 	w, err := NewFSWatcher(50*time.Millisecond, func(e ChangeEvent) {
 		eventCount.Add(1)
+		mu.Lock()
 		lastChange = e
+		mu.Unlock()
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -57,7 +63,10 @@ func TestFSWatcher_DetectsFileWrite(t *testing.T) {
 	if eventCount.Load() == 0 {
 		t.Error("expected at least one change event")
 	}
-	if lastChange.ChangeType == "" {
+	mu.Lock()
+	gotType := lastChange.ChangeType
+	mu.Unlock()
+	if gotType == "" {
 		t.Error("expected a non-empty change type")
 	}
 }

--- a/internal/infrastructure/webhook/notifier_test.go
+++ b/internal/infrastructure/webhook/notifier_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -44,12 +45,18 @@ func TestNotifier_DeliverySuccess(t *testing.T) {
 
 func TestNotifier_HMACSignature(t *testing.T) {
 	secret := "test-secret"
+	// The handler runs on the server's goroutine and the assertions below run on
+	// the test's, so everything crossing that boundary needs a lock.
+	var mu sync.Mutex
 	var receivedSig string
 	var receivedBody []byte
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		receivedSig = r.Header.Get("X-Roady-Signature")
-		receivedBody, _ = io.ReadAll(r.Body)
+		sig := r.Header.Get("X-Roady-Signature")
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		receivedSig, receivedBody = sig, body
+		mu.Unlock()
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer server.Close()
@@ -67,17 +74,21 @@ func TestNotifier_HMACSignature(t *testing.T) {
 
 	time.Sleep(200 * time.Millisecond)
 
-	if receivedSig == "" {
+	mu.Lock()
+	gotSig, gotBody := receivedSig, receivedBody
+	mu.Unlock()
+
+	if gotSig == "" {
 		t.Fatal("expected X-Roady-Signature header")
 	}
 
 	// Verify signature
 	mac := hmac.New(sha256.New, []byte(secret))
-	mac.Write(receivedBody)
+	mac.Write(gotBody)
 	expected := "sha256=" + hex.EncodeToString(mac.Sum(nil))
 
-	if receivedSig != expected {
-		t.Errorf("signature mismatch: got %s, want %s", receivedSig, expected)
+	if gotSig != expected {
+		t.Errorf("signature mismatch: got %s, want %s", gotSig, expected)
 	}
 }
 
@@ -158,13 +169,20 @@ func TestNotifier_EventFilter(t *testing.T) {
 }
 
 func TestPayloadFormat(t *testing.T) {
+	// Guarded for the same reason, and the decode error is carried back to the
+	// test goroutine rather than reported with t.Fatal from the handler's —
+	// t.Fatal must be called from the goroutine running the test.
+	var mu sync.Mutex
 	var receivedPayload Payload
+	var decodeErr error
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, _ := io.ReadAll(r.Body)
-		if err := json.Unmarshal(body, &receivedPayload); err != nil {
-			t.Fatal(err)
-		}
+		var p Payload
+		err := json.Unmarshal(body, &p)
+		mu.Lock()
+		receivedPayload, decodeErr = p, err
+		mu.Unlock()
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer server.Close()
@@ -176,7 +194,14 @@ func TestPayloadFormat(t *testing.T) {
 
 	time.Sleep(200 * time.Millisecond)
 
-	if receivedPayload.EventType != "plan.created" {
-		t.Errorf("expected event_type plan.created, got %s", receivedPayload.EventType)
+	mu.Lock()
+	got, err := receivedPayload, decodeErr
+	mu.Unlock()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.EventType != "plan.created" {
+		t.Errorf("expected event_type plan.created, got %s", got.EventType)
 	}
 }

--- a/pkg/infrastructure/webhook/server.go
+++ b/pkg/infrastructure/webhook/server.go
@@ -95,23 +95,37 @@ func (s *Server) Start() error {
 	// Recent events endpoint (for debugging)
 	mux.HandleFunc("/events", s.handleEvents)
 
-	s.server = &http.Server{
+	srv := &http.Server{
 		Addr:         s.addr,
 		Handler:      mux,
 		ReadTimeout:  15 * time.Second,
 		WriteTimeout: 15 * time.Second,
 	}
+	// Publish under the lock, then serve through the local copy. ListenAndServe
+	// blocks for the life of the server, so every caller runs Start in its own
+	// goroutine and Shutdown from another — an unguarded s.server is read and
+	// written concurrently by definition, not just under test.
+	s.mu.Lock()
+	s.server = srv
+	s.mu.Unlock()
 
 	log.Printf("Webhook server starting on %s", s.addr)
-	return s.server.ListenAndServe()
+	return srv.ListenAndServe()
 }
 
-// Shutdown gracefully shuts down the server.
+// Shutdown gracefully shuts down the server. Shutting down a server that was
+// never started is a no-op, so racing Shutdown ahead of Start returns nil
+// rather than blocking.
 func (s *Server) Shutdown(ctx context.Context) error {
-	if s.server == nil {
+	s.mu.RLock()
+	srv := s.server
+	s.mu.RUnlock()
+	if srv == nil {
 		return nil
 	}
-	return s.server.Shutdown(ctx)
+	// Shutdown outside the lock: it blocks until connections drain, and holding
+	// the mutex would stall every in-flight handler that needs it.
+	return srv.Shutdown(ctx)
 }
 
 func (s *Server) handleWebhook(provider string) http.HandlerFunc {


### PR DESCRIPTION
Replaces #62, which GitHub closed when its base branch (`fix/webhook-server-race`, now merged as #61) was deleted rather than retargeted. Same branch, same commit, now based on `main` — the diff is one config block, since #61's squash preserved the tree.

## Why

roady is a `klarlabs-studio` repo and `HOMEBREW_TAP_TOKEN` is a `klarlabs-studio` org secret — but the formula was pointed at `felixgeelhaar/homebrew-tap`, a personal repo that secret cannot reach.

briefkasten hit that combination first: v0.31.0 published all 22 signed artifacts and then failed on the brew step with

```
403 Resource not accessible by personal access token
```

A `403` rather than a `401` is the fine-grained-PAT signature — it authenticated, but the target repo is outside its scope.

## Sequencing note for whoever merges

`roady.rb` exists **only** in the personal tap. The first release after this lands creates it in the org tap, and the personal-tap copy stops being updated — anyone installed from `felixgeelhaar/tap` silently pins to their current version.

A `tap_migrations.json` entry in the personal tap (`{"roady": "klarlabs-studio/tap"}`) carries them over, but it has to come **after** that first release: a redirect pointing at a tap that does not yet hold the formula breaks the very install it exists to preserve. Neither tap contains that file today.

https://claude.ai/code/session_01BFsL9VmX5KHW8cnLMRPei3