### PR TITLE
chore(release): clear the deprecated goreleaser properties

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -102,7 +102,7 @@ checksum:
   name_template: 'checksums.txt'
 
 snapshot:
-  name_template: "{{ incpatch .Version }}-next"
+  version_template: "{{ incpatch .Version }}-next"
 
 changelog:
   sort: asc


### PR DESCRIPTION
`goreleaser check` reports deprecated properties that become hard errors in a future goreleaser. These are **pure renames** — nothing about what is built or published changes:

| Deprecated | Replacement |
|---|---|
| `archives.builds` | `archives.ids` |
| `archives.format: X` | `archives.formats: [X]` |
| `snapshot.name_template` | `snapshot.version_template` |

## Applied structurally, not by search-and-replace

The edit is confined to the top-level `archives:` / `snapshot:` blocks by line range, so a nested `builds:` elsewhere in the file is untouched.

That matters: a first attempt with an unbounded regex renamed the **top-level `builds:` section**, breaking the config completely — and reported success, because it only grepped for `DEPRECATED` lines and an errored run contains none. A check that cannot fail is worse than no check.

Verified per repo before committing:

- YAML parses
- the **top-level key set is unchanged** (this is what caught the bug above)
- `goreleaser check` runs without a config error

## Deliberately not included: `brews`

`brews` → `homebrew_casks` is also deprecated, and is **not** a rename. It publishes `Casks/<name>.rb` while `Formula/<name>.rb` remains in the tap — and a tap holding both under one name makes `brew install <name>` ambiguous, with brew preferring the formula. Users would silently keep receiving the older artifact.

That exact bug was removed from this tap today for `preflight` (formula 4.11.1 shadowing cask 4.12.0), `nomi` and `mnemos`. Ten repos still use `brews`, and every one has a Formula and no Cask, so a bulk migration would recreate it ten times over.

It needs per-repo sequencing — migrate, release, delete the stale formula in that order — and is tracked separately.
