### PR TITLE
feat(ci): give roady a release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,51 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+  # Re-drive a release that published its artifacts and then failed on a later
+  # step, without re-tagging. Dispatch against the TAG (`--ref v0.13.1`), not a
+  # branch: goreleaser takes its config and its version from the ref it runs on.
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    permissions:
+      # Widened here and only here: goreleaser creates the GitHub release and
+      # uploads its assets.
+      contents: write
+    env:
+      # checkout@v4 / setup-go@v5 / goreleaser-action@v6 still default to Node
+      # 20, which GitHub removes from runners 2026-09-16. Force Node 24 now so
+      # the workflow does not break when the runner drops it.
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+    steps:
+      - uses: actions/checkout@v4 # v4.2.2
+        with:
+          # goreleaser derives the version and changelog from tag history, so a
+          # shallow clone produces a wrong version and an empty changelog.
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5.4.0 # v5.4.0
+        with:
+          go-version: "1.26"
+          cache: true
+
+      - name: Run tests
+        run: go test ./...
+
+      - uses: goreleaser/goreleaser-action@v6 # v6.3.0
+        with:
+          version: "~> 2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # The klarlabs-studio org secret. goreleaser's brews: section consumes
+          # it to push Formula/roady.rb to klarlabs-studio/homebrew-tap -- the
+          # tap owned by the org that owns this repo, which is the scope this
+          # credential can write. A personal tap answers 403.
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -137,3 +137,16 @@ brews:
       bin.install "roady-plugin-mock"
     test: |
       system "#{bin}/roady --version"
+
+release:
+  # A re-drive (release.yml's workflow_dispatch) must be able to reach the step
+  # it is being re-driven for. By default goreleaser re-uploads every asset and
+  # dies on `422 already_exists` long before the brew push, so the recovery path
+  # would exist but never recover.
+  #
+  # These are two separate settings and only the second governs assets: `mode`
+  # is an enum over the release NOTES, `replace_existing_artifacts` over the
+  # uploaded ARTIFACTS. warden set only `mode` and its re-drive failed exactly
+  # this way, twice, before anyone noticed the key did something else.
+  mode: replace
+  replace_existing_artifacts: true


### PR DESCRIPTION
## Why

roady has a complete `.goreleaser.yaml` and **no workflow to run it**. The repo has `ci`, `nox-remediate`, `security` and `website` — nothing on tags. So `git push --tags` does nothing, and seven merged commits, including #63 moving the formula to the org tap, have no path out.

The `Formula/roady.rb` currently in `klarlabs-studio/homebrew-tap` is a copy I seeded by hand for exactly that reason. This replaces that stopgap with the real thing.

## Modelled on tokenops, with three deliberate differences

| addition | why |
|---|---|
| `workflow_dispatch` | Recover a release that published its artifacts then failed later, without re-tagging. briefkasten v0.31.0 failed exactly that way today and its cask had to be built by hand from `checksums.txt`. |
| `fetch-depth: 0` | goreleaser derives version and changelog from tag history; a shallow clone yields a wrong version and an empty changelog. |
| `go test ./...` | Don't publish a tag whose tests were never run. |

Permissions default to `read` and are widened to `contents: write` on the single job that needs it, rather than at workflow scope.

## The release block is the other half

`mode` governs the release **notes**; `replace_existing_artifacts` governs the uploaded **assets**. Only the second stops a re-drive dying on `422 already_exists` before it reaches the brew push. warden set only `mode`, believed its re-drive worked, and failed exactly that way twice — fixed there in klarlabs-studio/warden#129.

## Note

`goreleaser check` still reports `DEPRECATED: brews` — pre-existing, and untouched here. Migrating `brews:` → `homebrew_casks:` changes how users install (formula vs cask), which is a product decision rather than a mechanical fix, so it belongs in its own change.

https://claude.ai/code/session_01BFsL9VmX5KHW8cnLMRPei3