### PR TITLE
chore(release): publish a cask instead of a formula

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -116,27 +116,39 @@ changelog:
 # scope HOMEBREW_TAP_TOKEN — a klarlabs-studio org secret — can write to. An
 # org secret does not reach a personal repo, which answers 403: briefkasten's
 # v0.31.0 published every artifact and then failed exactly there.
-brews:
+# homebrew_casks replaces brews (deprecated in GoReleaser v2.16). Homebrew's
+# own guidance is that a cask, not a formula, is the right vehicle for a
+# pre-compiled binary -- the formula path generated something that only
+# pretended to build from source.
+homebrew_casks:
   - name: roady
     repository:
       owner: klarlabs-studio
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
-    directory: Formula
     homepage: "https://felixgeelhaar.github.io/roady/"
     description: "A planning-first system of record for software work."
     license: "MIT"
-    install: |
-      bin.install "roady"
-      bin.install "roady-plugin-linear"
-      bin.install "roady-plugin-jira"
-      bin.install "roady-plugin-github"
-      bin.install "roady-plugin-asana"
-      bin.install "roady-plugin-notion"
-      bin.install "roady-plugin-trello"
-      bin.install "roady-plugin-mock"
-    test: |
-      system "#{bin}/roady --version"
+    binaries:
+      - roady
+      - roady-plugin-linear
+      - roady-plugin-jira
+      - roady-plugin-github
+      - roady-plugin-asana
+      - roady-plugin-notion
+      - roady-plugin-trello
+      - roady-plugin-mock
+    hooks:
+      post:
+        # The release archives are not notarized, so Gatekeeper quarantines
+        # every binary on first run. A formula was never subject to this; a cask
+        # is, so without this the CLI and all seven plugins refuse to start.
+        # Stripped across staged_path rather than per-binary because there are
+        # eight of them.
+        install: |
+          if OS.mac?
+            system_command "xattr", args: ["-dr", "com.apple.quarantine", staged_path]
+          end
 
 release:
   # A re-drive (release.yml's workflow_dispatch) must be able to reach the step


### PR DESCRIPTION
## Why

`brews:` was deprecated in GoReleaser v2.16 and `goreleaser check` has been failing on it. Homebrew's own guidance is that a **cask**, not a formula, is the right vehicle for a pre-compiled binary — the formula path generated something that only pretended to build from source.

## This is not a purely mechanical rename

A cask-installed binary is subject to **Gatekeeper**; a formula-installed one was not. The release archives are unnotarized, so macOS quarantines them and they refuse to start. The post-install hook strips the attribute — **without it this change ships a package that installs cleanly and then does not run.**

All eight binaries are listed, and quarantine is stripped across `staged_path` rather than per-binary because of their number.

The formula's `test:` block has no cask equivalent and is dropped.

## Follow-up needed after this releases

`Formula/roady.rb` in `klarlabs-studio/homebrew-tap` becomes stale the moment the cask lands, and both would then exist under the same name. It needs deleting once a release has written `Casks/roady.rb`.

Anyone who installed the formula will not be migrated automatically — Homebrew's `tap_migrations.json` moves a name between taps, not from formula to cask within one. They will need `brew uninstall roady && brew install --cask roady`. Worth a line in the release notes.

`goreleaser check` passes.

https://claude.ai/code/session_01BFsL9VmX5KHW8cnLMRPei3