### PR TITLE
docs(readme): install from the org tap, and trust it first

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,14 @@ your agent.
 ## See it in 60 seconds
 
 ```bash
-brew install felixgeelhaar/tap/roady     # or: go install github.com/felixgeelhaar/roady/cmd/roady@latest
+brew trust klarlabs-studio/tap        # first time only
+brew install --cask klarlabs-studio/tap/roady     # or: go install github.com/felixgeelhaar/roady/cmd/roady@latest
 roady demo                               # scaffolds a sample project + shows drift
 ```
+
+Homebrew refuses to load a cask from a third-party tap it has not been told
+to trust, so the first install of anything from this tap needs
+`brew trust klarlabs-studio/tap` once — per machine, not per tool.
 
 The demo creates a `roady-demo/` directory with a deliberately drifted
 spec/plan, runs `roady drift detect`, and prints the next steps. Zero


### PR DESCRIPTION
The documented install had two problems.

**It pointed at the wrong tap** (warden, roady, tokenops only) — `felixgeelhaar/tap`, whose copy was removed when the casks moved to the org tap. It still resolves, because `tap_migrations.json` redirects it, but documenting a path that works only via a redirect is one deprecation away from breaking.

**And it fails on a fresh machine.** Homebrew will not load a cask from a third-party tap it has not been told to trust:

```
Error: Refusing to load cask klarlabs-studio/tap/NAME from untrusted tap klarlabs-studio/tap.
```

That gate arrived with the move to the org tap, and the error explains the refusal without explaining why the tap changed. `brew trust` is a per-machine decision, needed once for the tap rather than once per tool.

Same fix landed in klarlabs-studio/briefkasten#49.

https://claude.ai/code/session_01BFsL9VmX5KHW8cnLMRPei3