### PR TITLE
ci: bump pinned actions off the deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,15 +23,15 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: '1.26'
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
           # `latest` so the linter binary stays compatible with whatever
           # Go version go.mod targets (a pinned older version was built
@@ -52,10 +52,10 @@ jobs:
     # shipped broken. This job rebuilds and fails on any drift.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '22'
           cache: npm
@@ -83,10 +83,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: lint
     steps:
-    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Set up Go
-      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
+      uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
       with:
         go-version: '1.26'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,13 +24,13 @@ jobs:
       # the workflow does not break when the runner drops it.
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     steps:
-      - uses: actions/checkout@v4 # v4.2.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # goreleaser derives the version and changelog from tag history, so a
           # shallow clone produces a wrong version and an empty changelog.
           fetch-depth: 0
 
-      - uses: actions/setup-go@v5.4.0 # v5.4.0
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: "1.26"
           cache: true
@@ -38,7 +38,7 @@ jobs:
       - name: Run tests
         run: go test ./...
 
-      - uses: goreleaser/goreleaser-action@v6 # v6.3.0
+      - uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
           version: "~> 2"
           args: release --clean

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,11 +18,6 @@ jobs:
       # Widened here and only here: goreleaser creates the GitHub release and
       # uploads its assets.
       contents: write
-    env:
-      # checkout@v4 / setup-go@v5 / goreleaser-action@v6 still default to Node
-      # 20, which GitHub removes from runners 2026-09-16. Force Node 24 now so
-      # the workflow does not break when the runner drops it.
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -38,7 +38,7 @@ jobs:
       security-events: write
       pull-requests: write   # nox annotate
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install nox (pinned + sha256-verified binary)
         env:
           NOX_VERSION: "1.7.1"
@@ -65,7 +65,7 @@ jobs:
         run: nox scan . -format json,sarif -output nox-results || true
       - name: Upload SARIF to code scanning
         if: always() && hashFiles('nox-results/findings.sarif') != ''
-        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
+        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           sarif_file: nox-results/findings.sarif
       - name: Annotate PR

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -27,10 +27,10 @@ jobs:
       run:
         working-directory: website
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           # Astro 5+ requires Node 22.12+; pin to current LTS line.
           node-version: '22'
@@ -44,7 +44,7 @@ jobs:
         run: npm run build
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: website/dist
 
@@ -56,4 +56,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0


### PR DESCRIPTION
Every workflow run was annotating *"Node.js 20 is deprecated ... being forced to run on Node.js 24"*. GitHub is accommodating those actions today; when it stops, they fail rather than warn.

Bumps every pinned action to its current major — which is the Node 24 migration in each case. golangci-lint-action v9.0.0's release notes are literally *"we change Nodejs runtime from node20 to node24"*.

| Action | To |
| --- | --- |
| actions/checkout | v7.0.1 |
| actions/setup-go | v7.0.0 |
| actions/setup-node | v7.0.0 |
| actions/deploy-pages | v5.0.0 |
| actions/upload-pages-artifact | v5.0.0 |
| golangci/golangci-lint-action | v9.3.0 |
| goreleaser/goreleaser-action | v7.2.3 |
| github/codeql-action | v4.37.4 |
| actions/upload-artifact | v7.0.1 (already current) |
| sigstore/cosign-installer | v4.1.2 (already current) |

Also normalises the pinning. Some refs were SHAs and some were floating tags (`checkout@v4`, `setup-go@v5.4.0`, `goreleaser-action@v6`), which defeats the point of pinning the rest. Everything is now a SHA with the version as a trailing comment, so the pin stays readable without a lookup.

SHAs were resolved from the GitHub API rather than copied, and every workflow re-validated as YAML.

**Why a PR:** these are major bumps that can change action inputs. CI on this PR is the proof — in particular that `golangci-lint-action` v9 still accepts the `--new-from-rev` args form, and that the `mcp-apps` job's `setup-node` cache config still works.

The release path (`goreleaser-action` v7) is not exercised by PR CI, so it stays unproven until the next tag.

https://claude.ai/code/session_01CKxbiYE7cJ4PBbsBjarX6D