### PR TITLE
fix(ci): pass NOX_TOKEN explicitly; inherit does not cross the owner boundary

### DIFF
--- a/.github/workflows/nox-remediate.yml
+++ b/.github/workflows/nox-remediate.yml
@@ -15,4 +15,17 @@ permissions:
 jobs:
   remediate:
     uses: felixgeelhaar/.github/.github/workflows/nox-remediate.yml@main
-    secrets: inherit # passes NOX_TOKEN through when defined (needed to bump action pins)
+    # NOT `secrets: inherit`. That only passes secrets to reusable workflows in
+    # the same organisation or enterprise, and this one lives under the
+    # felixgeelhaar user account while this repo is in klarlabs-studio. Across
+    # that boundary inherit silently passes nothing, so the called workflow saw
+    # an empty NOX_TOKEN, fell back to GITHUB_TOKEN, and every remediation from
+    # 2026-07-27 onward died on "GitHub Actions is not permitted to create or
+    # approve pull requests".
+    #
+    # Naming the secret explicitly works because the expression is evaluated in
+    # this repo's context, where the klarlabs-studio organisation secret (ALL
+    # visibility) is available — the same way release.yml already consumes
+    # HOMEBREW_TAP_TOKEN directly.
+    secrets:
+      NOX_TOKEN: ${{ secrets.NOX_TOKEN }}


### PR DESCRIPTION
Every remediation run since **2026-07-27** failed with:

```
GraphQL: GitHub Actions is not permitted to create or approve pull requests
```

That is the `GITHUB_TOKEN` error, so `secrets.NOX_TOKEN` was empty in the called workflow. It is **not missing** — `klarlabs-studio` has had a `NOX_TOKEN` org secret with `ALL` visibility since 2026-07-03.

## Cause

Per [the docs](https://docs.github.com/en/actions/how-tos/reuse-automations/reuse-workflows), `secrets: inherit` only applies to *"workflows that call reusable workflows in the same organization or enterprise."*

| | caller | reusable workflow | same owner? | inherit works? |
|---|---|---|---|---|
| roady | `klarlabs-studio/roady` | `felixgeelhaar/.github` | ❌ | **no** |
| jirasdk | `felixgeelhaar/jirasdk` | `felixgeelhaar/.github` | ✅ | yes |
| specular | `felixgeelhaar/specular` | `felixgeelhaar/.github` | ✅ | yes |

Across that boundary inherit passes nothing **silently** — no warning, no failure; the called workflow just sees an empty value and takes its `GITHUB_TOKEN` fallback. That is why only roady broke, and why it broke only once it had something to propose.

## Fix

Name the secret explicitly. The expression is evaluated in *this* repository's context, where the org secret is available:

```yaml
secrets:
  NOX_TOKEN: ${{ secrets.NOX_TOKEN }}
```

Independent evidence that org secrets do reach this repo's workflows: `release.yml` consumes the `HOMEBREW_TAP_TOKEN` org secret directly, and the Homebrew tap has been updating correctly throughout.

## Rejected alternative

Adding a repo-level `NOX_TOKEN`. It would work, but it duplicates a credential to paper over a mechanism that was simply misunderstood, and leaves the same trap set for the next `klarlabs-studio` repo that calls a `felixgeelhaar` reusable workflow.

https://claude.ai/code/session_01CKxbiYE7cJ4PBbsBjarX6D