### PR TITLE
ci(security): add a changed-files gate on pull requests

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -39,6 +39,10 @@ jobs:
       pull-requests: write   # nox annotate
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Full history: the changed-files gate below diffs against
+          # origin/<base_ref>, which a depth-1 clone does not contain.
+          fetch-depth: 0
       - name: Install nox (pinned + sha256-verified binary)
         env:
           NOX_VERSION: "1.26.0"
@@ -139,6 +143,29 @@ jobs:
             jq '.findings[] | select((.Severity=="critical" or .Severity=="high") and ((.Status // "") == "")) | {severity:.Severity, rule:.RuleID, file:.Location.FilePath, line:.Location.StartLine}' "$f"
             exit 1
           fi
+      - name: Gate on changed files (pull requests)
+        # Asks the question the baseline gate above is a proxy for: does this
+        # change introduce a high or critical finding? Scoped to files the PR
+        # touches, so a pre-existing finding elsewhere neither blocks the PR
+        # nor needs a baseline entry to stay quiet.
+        #
+        # This matters here specifically. Accepting a single reviewed finding
+        # via the baseline does not work for plugin rules: nox/taint-analysis
+        # derives its fingerprint partly from the scan directory, so an entry
+        # generated anywhere but this runner does not match
+        # (nox-hq/nox-plugin-taint-analysis#37). A changed-files gate never
+        # needs the fingerprint to be stable, because it never has to
+        # recognise the same finding across two runs.
+        #
+        # -fail-on-degraded is set: a check that could not complete is not a
+        # clean result, and this is the gate that blocks.
+        if: github.event_name == 'pull_request'
+        run: |
+          nox scan . \
+            -changed-since "origin/${{ github.base_ref }}" \
+            -severity-threshold high \
+            -fail-on-degraded \
+            -format json -output nox-pr
       - name: Upload nox artifacts
         if: always() && hashFiles('nox-results/**') != ''
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
Adds a second gate that asks what the baseline gate is only a proxy for: **does this change introduce a high or critical finding?**

```
nox scan . -changed-since origin/$base_ref -severity-threshold high -fail-on-degraded
```

Scoped to the files the PR touches, so a pre-existing finding elsewhere neither blocks the PR nor needs a baseline entry to stay quiet.

## Why this is better than a baseline diff here

Accepting a single reviewed finding via the baseline **does not work for plugin rules**. `nox/taint-analysis` derives its fingerprint partly from the scan directory ([taint#37](https://github.com/Nox-HQ/nox-plugin-taint-analysis/issues/37)) — `f2fc80a3` locally, `6a6e14b1` in a worktree, `2ec40d1d` on the runner, same commit and content. An entry generated anywhere but this runner never matches.

A changed-files gate never needs the fingerprint to be stable, because it never has to recognise the same finding across two runs. This is the pattern the 22 plugin repositories already use.

## Details

- `fetch-depth: 0` on checkout — a depth-1 clone has no `origin/<base_ref>` to diff against, and the gate would fail for the wrong reason.
- `-fail-on-degraded` is set on this gate; a check that could not complete is not a clean result. **Sharp edge:** nox counts *"installed plugins not listed in plugins.required"* as a degradation, so the flag is only safe where CI installs exactly the required set — which the step above does, by deriving the list from `.nox.yaml`.

## Not done

Removing the whole-file exclusion of `internal/infrastructure/cli/stderr.go`. That still needs the full-scan gate to stop enforcing on main, because the reviewed `TAINT-004` there cannot be waived any other way — `suppressions:` is ignored and `nox:ignore` is not honoured for plugin findings. Trading main-branch enforcement for a narrower waiver isn't obviously right, so the exclusion stays until a taint release makes a baseline entry durable.

This PR exercises the new gate on itself.

https://claude.ai/code/session_01CKxbiYE7cJ4PBbsBjarX6D