### PR TITLE
fix(mcp): report an unparseable spec from roady_status (#87, item 5)

### DIFF
--- a/internal/infrastructure/mcp/server.go
+++ b/internal/infrastructure/mcp/server.go
@@ -98,6 +98,40 @@ func mcpErr(friendly string) *mcpserver.StructuredResult {
 	}
 }
 
+// specHealth reports whether the project's spec currently parses.
+//
+// It exists because tools disagreed about whether a project was broken.
+// roady_status reads plan.json and state.json and never unmarshals the spec,
+// so it answered normally while spec.yaml held merge-conflict markers — the
+// server looked healthy and exactly one tool looked flaky. A caller reasonably
+// concluded roady was broken and stopped using it (#87).
+//
+// Returning the parse error rather than a boolean keeps the remedy in the same
+// place as the symptom: the message names the file, line and reason, the same
+// way the CLI does.
+func specHealth(svc *wiring.AppServices) error {
+	if svc == nil || svc.Spec == nil {
+		return nil // nothing loaded; not this function's failure to report
+	}
+	_, err := svc.Spec.LockStatus()
+	return err
+}
+
+// withSpecWarning prefixes a tool's answer with a spec-is-unparseable notice.
+//
+// The answer itself is still returned: status computed from plan.json is
+// genuinely useful even when the spec is broken, and withholding it would
+// trade one confusing outcome for another. What must not happen is returning
+// it as though nothing were wrong.
+func withSpecWarning(answer string, err error) string {
+	if err == nil {
+		return answer
+	}
+	return "WARNING: this project's spec.yaml does not currently parse, so any " +
+		"tool that reads it will fail until it is repaired. Run roady_spec_validate " +
+		"for the details.\nCause: " + err.Error() + "\n\n" + answer
+}
+
 // mcpErrCause is mcpErr with the diagnosis attached.
 //
 // The friendly sentence tells a caller what failed; the wrapped error tells
@@ -1718,7 +1752,9 @@ func (s *Server) handleStatus(ctx context.Context, args StatusArgs) (any, error)
 		return mcpErrCause("Failed to load plan. Generate a plan first with 'roady plan generate'.", err), nil
 	}
 	if plan == nil {
-		return "No plan found. Run roady_generate_plan first.", nil
+		// Also warned here: "generate a plan" is bad advice when the spec is
+		// unparseable, because generating one reads it and will fail too.
+		return withSpecWarning("No plan found. Run roady_generate_plan first.", specHealth(svc)), nil
 	}
 
 	state, err := svc.Plan.GetState()
@@ -1726,7 +1762,7 @@ func (s *Server) handleStatus(ctx context.Context, args StatusArgs) (any, error)
 		return mcpErrCause("Failed to load execution state. Ensure a plan has been generated.", err), nil
 	}
 	if state == nil {
-		return "No execution state found.", nil
+		return withSpecWarning("No execution state found.", specHealth(svc)), nil
 	}
 
 	// Parse filters
@@ -1836,6 +1872,14 @@ func (s *Server) handleStatus(ctx context.Context, args StatusArgs) (any, error)
 			"counts":         counts,
 			"tasks":          tasks,
 		}
+		// A machine reader gets the same signal the text path prints, rather
+		// than a clean object that implies a healthy project.
+		if err := specHealth(svc); err != nil {
+			output["spec_valid"] = false
+			output["spec_error"] = err.Error()
+		} else {
+			output["spec_valid"] = true
+		}
 
 		jsonBytes, err := json.Marshal(output)
 		if err != nil {
@@ -1859,7 +1903,7 @@ func (s *Server) handleStatus(ctx context.Context, args StatusArgs) (any, error)
 		}
 	}
 
-	return statusStr, nil
+	return withSpecWarning(statusStr, specHealth(svc)), nil
 }
 
 // isTaskUnlockedByDeps checks if all dependencies are complete

--- a/internal/infrastructure/mcp/spec_health_test.go
+++ b/internal/infrastructure/mcp/spec_health_test.go
@@ -1,0 +1,78 @@
+package mcp
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// Tools must not disagree about whether the project is broken. roady_status
+// reads plan.json and state.json and never unmarshals the spec, so it answered
+// normally while spec.yaml held merge-conflict markers — the server looked
+// healthy while exactly one tool looked flaky, and the reporter concluded
+// roady was broken rather than their file (#87, item 5).
+func TestWithSpecWarning(t *testing.T) {
+	tests := []struct {
+		name   string
+		answer string
+		err    error
+		want   []string
+		absent []string
+	}{
+		{
+			name:   "healthy spec leaves the answer untouched",
+			answer: "Tasks: 3 total",
+			err:    nil,
+			want:   []string{"Tasks: 3 total"},
+			absent: []string{"WARNING", "Cause:"},
+		},
+		{
+			name:   "unparseable spec is announced, and the answer still returned",
+			answer: "Tasks: 3 total",
+			err:    errors.New("load spec: failed to unmarshal spec: yaml: line 11: could not find expected ':'"),
+			// The answer survives: status computed from plan.json is useful even
+			// when the spec is broken. What must not happen is returning it as
+			// though nothing were wrong.
+			want: []string{
+				"WARNING",
+				"does not currently parse",
+				"roady_spec_validate",
+				"yaml: line 11",
+				"Tasks: 3 total",
+			},
+		},
+		{
+			name:   "the remedy is named, not just the symptom",
+			answer: "No plan found. Run roady_generate_plan first.",
+			err:    errors.New("load spec: bad yaml"),
+			// "generate a plan" is bad advice when the spec cannot be read,
+			// because generating one reads it and fails too.
+			want: []string{"WARNING", "roady_spec_validate", "No plan found"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := withSpecWarning(tc.answer, tc.err)
+			for _, w := range tc.want {
+				if !strings.Contains(got, w) {
+					t.Errorf("output = %q, want it to contain %q", got, w)
+				}
+			}
+			for _, a := range tc.absent {
+				if strings.Contains(got, a) {
+					t.Errorf("output = %q, want it NOT to contain %q", got, a)
+				}
+			}
+		})
+	}
+}
+
+// specHealth must not invent a failure when there are no services to ask.
+// Reporting "spec is broken" for a project that was never loaded would be the
+// same class of error in the opposite direction.
+func TestSpecHealthWithoutServices(t *testing.T) {
+	if err := specHealth(nil); err != nil {
+		t.Errorf("specHealth(nil) = %v, want nil", err)
+	}
+}


### PR DESCRIPTION
Addresses item 5 of #87: **tools disagreed about whether the project was broken.**

`roady_status` reads `plan.json` and `state.json` and never unmarshals the spec, so it answered normally while `spec.yaml` held merge-conflict markers. The server looked healthy and exactly one tool looked flaky — which is why the reporter concluded roady was broken rather than their file, retried with smaller payloads, and hand-edited a backlog file instead.

## Change

Status checks whether the spec parses and says so when it doesn't, on **every** return path including the early ones. The most misleading was:

> No plan found. Run roady_generate_plan first.

Generating a plan reads the spec, so that advice could never have worked.

The answer is still returned alongside the warning — task counts from `plan.json` are useful while the spec is broken, and withholding them would trade one confusing outcome for another. JSON output gains `spec_valid` / `spec_error` so a machine reader gets the same signal instead of a clean object implying health.

## Verified against the corrupt project from #84

```
before   No plan found. Run roady_generate_plan first.

after    WARNING: this project's spec.yaml does not currently parse, so any tool
         that reads it will fail until it is repaired. Run roady_spec_validate
         for the details.
         Cause: load spec: failed to unmarshal spec: yaml: line 11: could not find expected ':'

         No plan found. Run roady_generate_plan first.
```

A healthy project produces **no** warning — checked, so this doesn't trade a false negative for a false positive.

Note the remedy it names, `roady_spec_validate`, does exist and is registered — see my comment on #87 about the stale client tool list, which is why it appeared missing.

Items 2, 3 and 4 of #87 (surface size, deprecated tools, naming) are untouched here — they're design calls worth taking separately.

https://claude.ai/code/session_01CKxbiYE7cJ4PBbsBjarX6D