### PR TITLE
fix(mcp): stop error results failing strict client schema validation (#92)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Tool results with no structured payload no longer fail strict client
+  schema validation.** Every error result encoded
+  `"structuredContent": null`, which matches no object schema, so a strict
+  client rejected the whole result — including the text content explaining
+  what happened. A caller could not distinguish "the operation failed" from
+  "the response could not be encoded", and for a mutating tool that is the
+  difference between knowing a write applied and guessing (#92).
+
+  The defect was in `go.klarlabs.de/mcp`, whose `StructuredResult` encoded a
+  nil payload as `null` rather than omitting the field; fixed upstream in
+  v1.24.1 and picked up here. roady needed no code change, but it now asserts
+  the wire format itself — roady is what emits these results, and a future
+  dependency change reintroducing the null would otherwise stay invisible
+  until a client rejected it.
+
+  Worth noting for anyone who hit this: the two tools named in the report were
+  not at fault. One call passed `status: "pending"`, which is not a valid
+  value, and the handler's "Invalid status" message was correct — the encoding
+  discarded it.
+
 ## [0.22.0] - 2026-08-09
 
 Closes #87 in full: the MCP surface is now groupable, named after the CLI, and

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/mattn/go-isatty v0.0.22
 	github.com/spf13/cobra v1.10.2
 	go.klarlabs.de/fortify v1.8.1
-	go.klarlabs.de/mcp v1.22.0
+	go.klarlabs.de/mcp v1.24.1
 	go.klarlabs.de/statekit v1.13.2
 	golang.org/x/oauth2 v0.36.0
 	google.golang.org/grpc v1.83.0
@@ -60,6 +60,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.44.0 // indirect
 	golang.org/x/net v0.56.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
-	golang.org/x/text v0.39.0 // indirect
+	golang.org/x/text v0.40.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260630182238-925bb5da69e7 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -118,8 +118,8 @@ github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavM
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
 go.klarlabs.de/fortify v1.8.1 h1:gyzJ7ESNe/Qf65DhGCT1WPWDyphgEDApb2QTx3Gd2m0=
 go.klarlabs.de/fortify v1.8.1/go.mod h1:x4Rnk8xt8ckJ8Pxe5SsXZVfGYjJIoOHx67DBl5Ncis8=
-go.klarlabs.de/mcp v1.22.0 h1:2ufVDqJT2/+kt5zd8B9HjbxJUbz3DYEVe43PqwTQ/QI=
-go.klarlabs.de/mcp v1.22.0/go.mod h1:ZeezqVm3aJFDN2+a7W0BVrLcEDhD2tdA+tQb+Klv5FE=
+go.klarlabs.de/mcp v1.24.1 h1:G/4ogbFXPx4TWwrrrMTfh8VTVaMCiX33LeayXeKwGYs=
+go.klarlabs.de/mcp v1.24.1/go.mod h1:x8QPfhNe+wqkNcEwaAxiRHDbnnrXBleTcNQI8EH6SgU=
 go.klarlabs.de/statekit v1.13.2 h1:jhq2lJMMRo6CeVoryL2aEUj/DV5JldNscBOio9TEvmQ=
 go.klarlabs.de/statekit v1.13.2/go.mod h1:/0OfP+tXhnjz6t2FACqv4q5BDeNcqMytx+vMniPxxWc=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
@@ -151,8 +151,8 @@ golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=
 golang.org/x/sys v0.46.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
-golang.org/x/text v0.39.0 h1:UbZz4pLOvn600D6Oh6GGEI6VAmndrEBLv8/6BEXzyus=
-golang.org/x/text v0.39.0/go.mod h1:3UwRclnC2g0TU9x8PZiyfOajCd1zaUNHF9cvqcQZ+ZM=
+golang.org/x/text v0.40.0 h1:Ub2Z6/xjgF1WrYQz2nuITOEegKFtiIy+rieRJ5lHZKs=
+golang.org/x/text v0.40.0/go.mod h1:hpnzDAfGV753zIKo+wk3u1bVKCGPbrnF7+7LBF/UHVY=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gonum.org/v1/gonum v0.17.0 h1:VbpOemQlsSMrYmn7T2OUvQ4dqxQXU+ouZFQsZOx50z4=
 gonum.org/v1/gonum v0.17.0/go.mod h1:El3tOrEuMpv2UdMrbNlKEh9vd86bmQ6vqIcDwxEOc1E=

--- a/internal/infrastructure/mcp/structured_content_test.go
+++ b/internal/infrastructure/mcp/structured_content_test.go
@@ -1,0 +1,57 @@
+package mcp
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// A tool result carrying no structured payload must omit structuredContent,
+// not encode it as null.
+//
+// `null` matches no object schema, so a strict client rejects the entire
+// result during validation — including the text content that explains what
+// happened. The reporter of #92 hit this with an invalid status enum: the
+// handler correctly returned "Invalid status", and the encoding threw that
+// message away, leaving a schema-validation failure in its place. For the
+// mutating tool in the same report it was worse — the caller could not tell
+// whether the write had applied.
+//
+// The defect was in go.klarlabs.de/mcp (fixed in v1.24.1), but the assertion
+// belongs here too: roady is what emits these results, and a future
+// dependency change that reintroduced the null would otherwise be invisible
+// until a client rejected it.
+func TestErrorResultsOmitStructuredContent(t *testing.T) {
+	tests := []struct {
+		name   string
+		result any
+	}{
+		{"mcpErr", mcpErr("Invalid status. Use ready, in_progress, blocked, unassigned, or all.")},
+		{"mcpErrCause", mcpErrCause("Failed to load project at the given path.", errTest{})},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			b, err := json.Marshal(tc.result)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			got := string(b)
+
+			if strings.Contains(got, `"structuredContent":null`) {
+				t.Errorf("emits null structuredContent, which fails strict client validation:\n  %s", got)
+			}
+			// The text is the whole point of an error result; it must survive.
+			if !strings.Contains(got, `"text"`) {
+				t.Errorf("error result carries no text content: %s", got)
+			}
+			if !strings.Contains(got, `"isError":true`) {
+				t.Errorf("error result is not flagged as an error: %s", got)
+			}
+		})
+	}
+}
+
+type errTest struct{}
+
+func (errTest) Error() string { return "underlying cause" }


### PR DESCRIPTION
Closes #92.

Every tool result without a structured payload encoded:

```json
{"content":[{"type":"text","text":"Invalid status."}],"structuredContent":null,"isError":true}
```

`null` matches no object schema, so a strict client rejected the **entire** result during validation — including the text content that explained what happened. The caller could not distinguish *"the operation failed"* from *"the response could not be encoded"*, and for a mutating tool that's the difference between knowing a write applied and guessing.

## The defect was upstream

`go.klarlabs.de/mcp`'s `StructuredResult` encoded a nil payload as `null` rather than omitting the field. Fixed in [klarlabs-studio/mcp-go#139](https://github.com/klarlabs-studio/mcp-go/pull/139), released as **v1.24.1**, picked up here. **roady needs no code change of its own.**

A struct tag couldn't fix it upstream either: without `omitempty` a nil map encodes as `null`; with it, an empty non-nil `{}` is dropped too, and a tool whose schema permits `{}` loses the ability to say so. It needed a `MarshalJSON` distinguishing the two.

## The assertion still belongs here

roady is what emits these results. A future dependency change reintroducing the null would be invisible until a client rejected it, so the wire format is now asserted in roady's own suite.

**Verified as a real guard**, not just a passing test — pinning v1.24.0 back:

```
--- FAIL: TestErrorResultsOmitStructuredContent/mcpErr
    emits null structuredContent, which fails strict client validation
```

and green again on v1.24.1.

## The reported tools were not at fault

Worth stating plainly for @-the-reporter: `roady_tasks` and the transition tool behaved correctly. The failing calls passed `status: "pending"` and `status: "done"` — neither is a valid value (`ready`, `in_progress`, `blocked`, `unassigned`, `all`) — so the handler returned *"Invalid status"*, which was right. The encoding discarded that message and left a schema error in its place, which is exactly why it looked like a handler bug.

The diagnosis in the report — *"probably a code path that returns early without constructing the structured payload"* — was the right shape, one layer down from where you looked.

**Also worth knowing:** the report cites `roady_transition_task` on v0.22.0, but that release renamed it to `roady_task_transition` (#91). Your MCP client is holding a cached tool list from before the upgrade; a client restart will pick up the current surface.

The suggested round-trip test validating every tool's response against its declared `outputSchema` is a good idea and a bigger piece of work — worth its own issue.

https://claude.ai/code/session_01CKxbiYE7cJ4PBbsBjarX6D