### PR TITLE
feat(audit): separate unverifiable history from evidence of alteration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`roady audit verify` separates history it cannot check from evidence of
+  alteration.** Every finding was reported as one undifferentiated
+  "integrity violation", and running it on Roady's own trail printed
+  `Found 86 integrity violations` — a number that reads as a compromised log
+  and, read twice, teaches you to stop reading it.
+
+  None of the 86 were evidence of anything. Thirteen were appended to
+  events.jsonl by something other than Roady and carry no hash at all;
+  seventy-three predate the `hash_algo` field added in v0.16.0, so the
+  function that wrote their hash is no longer known and they can be neither
+  confirmed nor convicted. Zero failed under an algorithm this build can
+  verify.
+
+  Findings now carry a reason alongside the prose, and the command prints a
+  breakdown plus, when it applies, the line that was missing: *no entry
+  failed under an algorithm this build can verify — nothing here is evidence
+  of alteration.* An entry that names a known algorithm and still does not
+  reproduce is now reported as altered rather than as one more line of old
+  history, so a single tampered event sorts to the top of the summary instead
+  of hiding among eighty-six that merely got old.
+
+  Nothing is suppressed: every violation is still listed and the command
+  still exits 1. This is the same defect v0.16.0 set out to fix — three
+  distinct causes reported as one — finished on the reporting side.
+
+  Found by running `roady audit verify` on Roady while checking something
+  else.
+
+### Fixed
+
+- **The tampering test was passing for the wrong reason.** Its fixtures built
+  events without `hash_algo`, which both real writers stamp on everything
+  they append, so the test exercised the unverifiable-legacy path rather than
+  the tamper-detection path it named. Verified against the real behaviour
+  afterwards: altering an event that carries `hash_algo` is reported as
+  altered, and the summary's reassurance disappears.
+
 ## [0.22.1] - 2026-08-10
 
 ### Fixed

--- a/docs/audit-grc.md
+++ b/docs/audit-grc.md
@@ -62,14 +62,21 @@ an agent forwarding the run that spawned it knows more than the server does.
 
 ## When verification reports a problem
 
-`roady audit verify` distinguishes three things that all used to read as
+`roady audit verify` distinguishes four things that all used to read as
 "possible tampering":
 
 | Finding | Means |
 | --- | --- |
-| `content hash does not reproduce` | The entry was altered — **or** it predates a change to the hash algorithm. See below. |
+| `content hash does not reproduce under <algo>` | The entry names an algorithm this build knows, and its hash still does not reproduce. **This one means the entry was altered.** |
+| `predates the hash_algo field` | The entry names no algorithm, so the function that wrote its hash is unknown. It can be neither confirmed nor convicted. See below. |
 | `outside the chain` | The entry has no hash at all, so it was never chained. Something appended to `events.jsonl` directly instead of going through Roady. |
 | `cannot verify` | The entry was written by a Roady version using a hash algorithm this build does not know. Not an attack. |
+
+The command closes with a breakdown by cause, and — when no entry failed
+under a known algorithm — says so explicitly. That line is the one to read
+first: it is the difference between a log full of unverifiable history and a
+log somebody edited. Every finding is still listed and the command still
+exits non-zero either way, so nothing is suppressed by the distinction.
 
 ### Historical entries may be unverifiable
 

--- a/internal/infrastructure/cli/audit.go
+++ b/internal/infrastructure/cli/audit.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/felixgeelhaar/roady/internal/infrastructure/wiring"
 	"github.com/felixgeelhaar/roady/pkg/application"
+	"github.com/felixgeelhaar/roady/pkg/domain"
 	"github.com/spf13/cobra"
 )
 
@@ -26,7 +27,7 @@ var auditVerifyCmd = &cobra.Command{
 		service := application.NewAuditService(workspace.Repo)
 
 		fmt.Println("Verifying audit trail integrity...")
-		violations, err := service.VerifyIntegrity()
+		violations, err := service.VerifyIntegrityDetailed()
 		if err != nil {
 			return fmt.Errorf("verification failed: %w", err)
 		}
@@ -38,7 +39,37 @@ var auditVerifyCmd = &cobra.Command{
 
 		fmt.Printf("Found %d integrity violations:\n", len(violations))
 		for _, v := range violations {
-			fmt.Printf("  - %s\n", v)
+			fmt.Printf("  - %s\n", v.Message)
+		}
+
+		// A bare count invites the wrong conclusion in both directions. A log
+		// carrying old entries nobody can check reads as compromised, and a
+		// single altered entry buried in a hundred of them reads as more of the
+		// same. Say which is which, and say plainly when nothing failed under an
+		// algorithm this build can actually verify.
+		counts := map[domain.ViolationKind]int{}
+		for _, v := range violations {
+			counts[v.Kind]++
+		}
+		fmt.Println("\nSummary:")
+		for _, row := range []struct {
+			kind  domain.ViolationKind
+			label string
+		}{
+			{domain.KindHashMismatch, "altered after writing (hash does not reproduce under the algorithm named)"},
+			{domain.KindUnhashed, "appended outside roady (no hash)"},
+			{domain.KindDuplicate, "duplicated in the log"},
+			{domain.KindMissingParent, "referencing a removed parent"},
+			{domain.KindUnknownAlgo, "written with an algorithm this build cannot verify"},
+			{domain.KindLegacyUnverifiable, "predating hash_algo, unverifiable either way"},
+		} {
+			if n := counts[row.kind]; n > 0 {
+				fmt.Printf("  %4d  %s\n", n, row.label)
+			}
+		}
+		if counts[domain.KindHashMismatch] == 0 {
+			fmt.Println("\nNo entry failed under an algorithm this build can verify:" +
+				" nothing here is evidence of alteration.")
 		}
 		os.Exit(1)
 		return nil

--- a/pkg/application/audit_service.go
+++ b/pkg/application/audit_service.go
@@ -66,6 +66,25 @@ type rawEventLoader interface {
 }
 
 func (s *AuditService) VerifyIntegrity() ([]string, error) {
+	violations, err := s.VerifyIntegrityDetailed()
+	if err != nil {
+		return nil, err
+	}
+	if len(violations) == 0 {
+		return nil, nil
+	}
+	out := make([]string, 0, len(violations))
+	for i := range violations {
+		out = append(out, violations[i].Message)
+	}
+	return out, nil
+}
+
+// VerifyIntegrityDetailed is VerifyIntegrity with the reason for each finding
+// kept alongside it, so a caller can report how many entries failed under an
+// algorithm this build knows — the only count that can mean tampering —
+// separately from history it merely cannot check.
+func (s *AuditService) VerifyIntegrityDetailed() ([]domain.ChainViolation, error) {
 	// Verify against the raw log: LoadEvents deduplicates so projections
 	// stay correct, but a reviewer should still be told the log contains
 	// the same event twice.
@@ -92,7 +111,7 @@ func (s *AuditService) VerifyIntegrity() ([]string, error) {
 		})
 	}
 
-	return domain.VerifyChain(entries), nil
+	return domain.VerifyChainDetailed(entries), nil
 }
 
 // GetVelocity returns the average verified tasks per day over the last 7 days.

--- a/pkg/application/audit_verify_test.go
+++ b/pkg/application/audit_verify_test.go
@@ -29,6 +29,11 @@ func linked(actor string, n int, parent string) []domain.Event {
 			Action:    "task.transition",
 			Actor:     actor,
 			PrevHash:  prev,
+			// Both real writers stamp this on every event they append. Leaving
+			// it off made these fixtures exercise the pre-hash_algo path, where
+			// a hash that does not reproduce cannot be attributed to tampering
+			// — so the tampering test was passing for the wrong reason.
+			HashAlgo: domain.HashAlgoCurrent,
 		}
 		e.Hash = e.CalculateHash()
 		out = append(out, e)

--- a/pkg/domain/chain.go
+++ b/pkg/domain/chain.go
@@ -31,7 +31,53 @@ type ChainEntry struct {
 	Matches bool
 }
 
-// VerifyChain reports every way the log fails to hold together.
+// ViolationKind names why an entry failed, so a caller can count the kinds
+// apart instead of re-deriving them from the message text.
+//
+// The distinction that carries weight is KindHashMismatch against
+// KindLegacyUnverifiable. Both are entries whose hash does not reproduce, but
+// only the first is written with an algorithm this build knows, which makes it
+// the only one that can mean the content was altered. The second predates
+// hash_algo and cannot be checked either way. Reporting a count of both
+// together is what turns a real finding into one line among dozens nobody
+// reads.
+type ViolationKind int
+
+const (
+	KindDuplicate ViolationKind = iota
+	KindUnhashed
+	KindUnknownAlgo
+	KindHashMismatch
+	KindLegacyUnverifiable
+	KindMissingParent
+)
+
+// ChainViolation is one finding, with the reason kept separate from the prose
+// so callers do not match on message text.
+type ChainViolation struct {
+	Kind    ViolationKind
+	Index   int
+	ID      string
+	Message string
+}
+
+// VerifyChain reports every way the log fails to hold together, as messages.
+//
+// It is a thin formatting layer over VerifyChainDetailed so that both share one
+// implementation, for the same reason the two writers to events.jsonl do.
+func VerifyChain(entries []ChainEntry) []string {
+	detailed := VerifyChainDetailed(entries)
+	if len(detailed) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(detailed))
+	for i := range detailed {
+		out = append(out, detailed[i].Message)
+	}
+	return out
+}
+
+// VerifyChainDetailed reports every way the log fails to hold together.
 //
 // The log is verified as a hash-linked graph rather than a strict sequence.
 // Two collaborators appending concurrently produce branches from a shared
@@ -43,17 +89,26 @@ type ChainEntry struct {
 // PrevHash: altering content or reparenting an entry breaks that entry's own
 // hash. What the links still prove is that no entry which something else
 // references has been removed.
-func VerifyChain(entries []ChainEntry) []string {
-	var violations []string
+func VerifyChainDetailed(entries []ChainEntry) []ChainViolation {
+	var violations []ChainViolation
+
+	add := func(kind ViolationKind, i int, id, format string, args ...any) {
+		violations = append(violations, ChainViolation{
+			Kind:    kind,
+			Index:   i,
+			ID:      id,
+			Message: fmt.Sprintf(format, args...),
+		})
+	}
 
 	present := make(map[string]bool, len(entries))
 	seenIDs := make(map[string]int, len(entries))
 	for i := range entries {
 		present[entries[i].Hash] = true
 		if first, dup := seenIDs[entries[i].ID]; dup && entries[i].ID != "" {
-			violations = append(violations, fmt.Sprintf(
+			add(KindDuplicate, i, entries[i].ID,
 				"Event %d (%s): duplicate of event %d. The log contains the same event twice.",
-				i, entries[i].ID, first))
+				i, entries[i].ID, first)
 			continue
 		}
 		if entries[i].ID != "" {
@@ -69,9 +124,9 @@ func VerifyChain(entries []ChainEntry) []string {
 		// tampering when the cause is usually something appending to the log
 		// without going through Roady.
 		if e.Hash == "" {
-			violations = append(violations, fmt.Sprintf(
+			add(KindUnhashed, i, e.ID,
 				"Event %d (%s): recorded without a hash, so it is outside the chain. Something appended to events.jsonl directly instead of through roady.",
-				i, orUnidentified(e.ID)))
+				i, orUnidentified(e.ID))
 			continue
 		}
 
@@ -79,25 +134,38 @@ func VerifyChain(entries []ChainEntry) []string {
 		// be checked. Report that plainly instead of calling it tampering: a
 		// false accusation is how a security signal gets ignored.
 		if !e.Verifiable {
-			violations = append(violations, fmt.Sprintf(
+			add(KindUnknownAlgo, i, e.ID,
 				"Event %d (%s): written with hash algorithm %q, which this build cannot verify. Upgrade roady or treat this entry as unverified.",
-				i, e.ID, e.HashAlgo))
+				i, e.ID, e.HashAlgo)
 			continue
 		}
 
 		// Self-hash. Covers content and parentage together.
 		if !e.Matches {
-			violations = append(violations, fmt.Sprintf(
-				"Event %d (%s): content hash does not reproduce. Either the entry was altered, or it predates a change to the hash algorithm (see docs/audit-grc.md).",
-				i, e.ID))
+			// An entry that names no algorithm predates hash_algo, so its hash
+			// was written by a function this build no longer has. It cannot be
+			// confirmed and it cannot be convicted. Kept as a violation, since
+			// unverifiable history is a real gap, but counted apart: an entry
+			// that names a known algorithm and still fails to reproduce is the
+			// only one of the two that can mean tampering, and it has to stay
+			// findable rather than sit in a pile of entries that merely got old.
+			if e.HashAlgo == "" {
+				add(KindLegacyUnverifiable, i, e.ID,
+					"Event %d (%s): predates the hash_algo field, so the algorithm that wrote its hash is unknown and the entry cannot be verified either way (see docs/audit-grc.md).",
+					i, e.ID)
+				continue
+			}
+			add(KindHashMismatch, i, e.ID,
+				"Event %d (%s): content hash does not reproduce under %q, the algorithm it names. The entry was altered after it was written (see docs/audit-grc.md).",
+				i, e.ID, e.HashAlgo)
 			continue
 		}
 
 		// Parent resolution.
 		if e.PrevHash != "" && !present[e.PrevHash] {
-			violations = append(violations, fmt.Sprintf(
+			add(KindMissingParent, i, e.ID,
 				"Event %d (%s): missing parent %s. An earlier event has been removed.",
-				i, e.ID, shortHash(e.PrevHash)))
+				i, e.ID, shortHash(e.PrevHash))
 		}
 	}
 

--- a/pkg/domain/chain_test.go
+++ b/pkg/domain/chain_test.go
@@ -64,7 +64,11 @@ func TestVerifyChainDistinguishesItsFindings(t *testing.T) {
 	}{
 		{"no hash is not tampering", ChainEntry{ID: "x", Verifiable: true}, "outside the chain"},
 		{"unknown algorithm is not tampering", ChainEntry{ID: "x", Hash: "h", HashAlgo: "sha512-v9"}, "cannot verify"},
-		{"content that does not reproduce", ChainEntry{ID: "x", Hash: "h", Verifiable: true}, "does not reproduce"},
+		// A hash that does not reproduce means two different things depending on
+		// whether the entry says what wrote it. Only the first can be called
+		// tampering; the second is history nobody can check.
+		{"mismatch under a named algorithm is tampering", ChainEntry{ID: "x", Hash: "h", HashAlgo: "sha256-canonical-v1", Verifiable: true}, "does not reproduce"},
+		{"mismatch with no named algorithm is unverifiable, not tampering", ChainEntry{ID: "x", Hash: "h", Verifiable: true}, "predates the hash_algo field"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
roady audit verify reported every finding as one undifferentiated
"integrity violation". Run on Roady's own trail it printed
"Found 86 integrity violations", which reads as a compromised log and,
read twice, teaches you to stop reading it.

None of the 86 were evidence of anything. 13 carry no hash at all —
something appended to events.jsonl without going through roady. 73 predate
the hash_algo field added in v0.16.0, so the function that wrote their hash
is no longer known and they can be neither confirmed nor convicted. Zero
failed under an algorithm this build can verify.

Findings now carry a Kind alongside the prose, so the CLI counts causes
apart instead of matching on message text, and prints the line that was
missing: no entry failed under an algorithm this build can verify, so
nothing here is evidence of alteration. An entry that names a known
algorithm and still does not reproduce is reported as altered rather than as
one more line of old history — so a single tampered event sorts to the top
of the summary instead of hiding among 86 that merely got old. Verified by
altering a modern event in a copy of the trail: it reports "1 altered after
writing", the reassurance disappears, exit stays 1.

Nothing is suppressed. Every violation is still listed, the exit code is
unchanged, and an entry whose hash_algo is stripped moves between categories
rather than out of the report.

VerifyChain keeps its []string signature and becomes a formatting layer over
VerifyChainDetailed, so the two writers to events.jsonl still share one
implementation — the property the file was built around.

Also fixes a test that passed for the wrong reason: its fixtures built events
without hash_algo, which both real writers stamp on everything they append,
so the tamper-detection test was exercising the unverifiable-legacy path
instead.

This is v0.16.0's defect — three distinct causes reported as one — finished
on the reporting side.

Claude-Session: https://claude.ai/code/session_01CKxbiYE7cJ4PBbsBjarX6D
