### PR TITLE
chore(security): nox remediation (deps + actions)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -60,7 +60,7 @@ jobs:
       # the tool's own signal, and it covers OSV lookups and lockfile parses,
       # not just plugins.
       - name: Scan
-        uses: nox-hq/nox@44788ecbc9e150398f6de53face82d90b454c9ab # v1.29.0
+        uses: nox-hq/nox@432259d18ae874a861c7a51e9e42ba8fc46ae604 # v1.29.1
         with:
           path: .
           format: json,sarif
@@ -71,7 +71,7 @@ jobs:
 
       - name: Upload SARIF to code scanning
         if: always() && hashFiles('nox-results/results.sarif') != ''
-        uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
         with:
           sarif_file: nox-results/results.sarif
       - name: Gate on net-new critical/high findings


### PR DESCRIPTION
Automated remediation by `nox fix --actions`: OSV-vulnerable dependency upgrades plus outdated and mutable GitHub Actions pins bumped to their SHA-pinned latest release. Replaces dependabot.